### PR TITLE
models: add time sync method to azure importer

### DIFF
--- a/src/__tests__/unit/lib/azure-importer/index.test.ts
+++ b/src/__tests__/unit/lib/azure-importer/index.test.ts
@@ -146,7 +146,7 @@ describe('lib/azure-importer: ', () => {
         azureModel.execute([
           {
             timestamp: '2023-11-02T10:35:00.000Z',
-            duration: 3600,
+            duration: 300,
             'azure-observation-window': '5 mins',
             'azure-observation-aggregation': 'average',
             'azure-subscription-id': '9de7e19f-8a18-4e73-9451-45fc74e7d0d3',
@@ -157,7 +157,7 @@ describe('lib/azure-importer: ', () => {
       ).resolves.toEqual([
         {
           timestamp: '2023-11-02T10:35:00.000Z',
-          duration: 3600,
+          duration: 300,
           'cpu-util': '3.14',
           'mem-availableGB': 0.5,
           'mem-usedGB': 0.5,

--- a/src/lib/azure-importer/index.ts
+++ b/src/lib/azure-importer/index.ts
@@ -373,8 +373,6 @@ export class AzureImporterModel implements IOutputModelInterface {
 
   /**
    * Calculates number of seconds covered by each individual input using azure-time-window value
-   * @param params
-   * @returns number
    */
   private calculateDurationPerInput(params: AzureInputs): number {
     const window = params.window;

--- a/src/lib/azure-importer/index.ts
+++ b/src/lib/azure-importer/index.ts
@@ -371,6 +371,11 @@ export class AzureImporterModel implements IOutputModelInterface {
     };
   }
 
+  /**
+   * Calculates number of seconds covered by each individual input using azure-time-window value
+   * @param params
+   * @returns number
+   */
   private calculateDurationPerInput(params: AzureInputs): number {
     const window = params.window;
     const splits = window.split(' ', 2);


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
Previously the data returned by the `azure-importer` could not integrate correctly with SCI because of a mismatch in the units of time. Azure can only report in intervals of >1 minute, whereas `SCI` requires units of seconds.

Currently, each observation reports the `duration` for the entire observation period in each `input` rather than the number of seconds each `input` covers. This PR fixes that by calculating the number of seconds represented by each azure observation window and writign that to `input[duration]` such that each `input` is time synced correctly.

The `SCI` model handles all downstream time conversions.


Closes #250 

<!-- Make sure tests and lint pass on CI. -->

