### PR TITLE
lib: simplify supercomputer calculation logic

### DIFF
--- a/src/types/impl.ts
+++ b/src/types/impl.ts
@@ -25,7 +25,7 @@ export type Children = {
     pipeline: string[];
     config: Config;
     inputs: ModelParams[];
-    children: Children;
+    children?: Children;
     outputs?: ModelParams[];
     'aggregated-outputs'?: AggregationResult;
   };


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- Before these changes, processing of top-level and nested children was mixed in `calculateOutputsForChild` method, which led to a number of conditions with `areChildrenNested`.
- Now top-level children-specific logic is moved to a `compute` method while nested children processing logic was extracted to `computeChildren`. It allowed to unify processing of all children inside of `calculateOutputsForChild` method and got rid of all `areChildrenNested` conditions.


<!-- Make sure tests and lint pass on CI. -->

