### PR TITLE
Add aggregation feature

### DIFF
--- a/examples/impls/functional/sci-e.yml
+++ b/examples/impls/functional/sci-e.yml
@@ -1,14 +1,18 @@
 name: sci-e-demo
 description:
 tags:
+aggregation:
+  metrics:
+    - energy
+  type: both
 initialize:
   plugins:
     'sci-e':
-      model: SciEModel
+      model: SciE
       path: "@grnsft/if-models"
 tree:
   children:
-    child:
+    child-1:
       pipeline:
         - sci-e
       config:
@@ -17,3 +21,27 @@ tree:
         - timestamp: 2023-08-06T00:00
           duration: 3600
           energy-cpu: 0.001
+        - timestamp: 2023-08-06T05:00
+          duration: 3600
+          energy-cpu: 0.001
+        - timestamp: 2023-08-06T10:00
+          duration: 3600
+          energy-cpu: 0.001
+    child-2:
+      pipeline:
+        - sci-e
+      config:
+        sci-e:
+      inputs:
+        - timestamp: 2023-08-06T00:00
+          duration: 3600
+          energy-cpu: 0.001
+          energy: 0.001
+        - timestamp: 2023-08-06T05:00
+          duration: 3600
+          energy-cpu: 0.001
+          energy: 0.001
+        - timestamp: 2023-08-06T10:00
+          duration: 3600
+          energy-cpu: 0.001
+          energy: 0.001

--- a/src/__tests__/unit/lib/aggregator.test.ts
+++ b/src/__tests__/unit/lib/aggregator.test.ts
@@ -1,91 +1,86 @@
 import {aggregate} from '../../../lib/aggregator';
 
-import {STRINGS, PARAMETERS} from '../../../config';
+// import { STRINGS, PARAMETERS } from '../../../config';
 
-import {ERRORS} from '../../../util/errors';
+//import { ERRORS } from '../../../util/errors';
 
-const {INVALID_AGGREGATION_METHOD, METRIC_MISSING} = STRINGS;
+import {basicTree, basicContext} from './impls/aggregation-test-impls';
 
-const {InvalidAggregationParams} = ERRORS;
+// const { INVALID_AGGREGATION_METHOD, METRIC_MISSING } = STRINGS;
+
+// const { InvalidAggregationParams } = ERRORS;
 
 describe('lib/aggregator: ', () => {
   describe('aggregate(): ', () => {
     it('throws error if aggregation method is none.', () => {
-      const inputs = [{}];
-      const metrics = ['total-resources'];
-
-      const expectedMessage = INVALID_AGGREGATION_METHOD('none');
-
       expect.assertions(1);
-
-      try {
-        aggregate(inputs, metrics, PARAMETERS);
-      } catch (error) {
-        expect(error).toEqual(new InvalidAggregationParams(expectedMessage));
-      }
-    });
-
-    it('throws error if metric is not found while aggregation.', () => {
-      const inputs = [
-        {
-          'ram-util': 10,
-        },
-      ];
-      const metrics = ['cpu-util'];
-
-      const expectedMessage = METRIC_MISSING(metrics[0], 0);
-
-      expect.assertions(1);
-
-      try {
-        aggregate(inputs, metrics, PARAMETERS);
-      } catch (error) {
-        expect(error).toEqual(new InvalidAggregationParams(expectedMessage));
-      }
-    });
-
-    it('should successfully calculate avg.', () => {
-      const inputs = [
-        {
-          'cpu-util': 10,
-        },
-        {
-          'cpu-util': 20,
-        },
-      ];
-      const metrics = ['cpu-util'];
-
-      const expectedKey = `aggregated-${Object.keys(inputs[0])[0]}`;
-      const expectedValue = (inputs[0]['cpu-util'] + inputs[1]['cpu-util']) / 2;
-      const expectedResult = {
-        [`${expectedKey}`]: expectedValue,
-      };
-
-      const aggregatedResult = aggregate(inputs, metrics, PARAMETERS);
-
-      expect(aggregatedResult).toEqual(expectedResult);
-    });
-
-    it('should successfully calculate sum.', () => {
-      const inputs = [
-        {
-          'disk-io': 10,
-        },
-        {
-          'disk-io': 20,
-        },
-      ];
-      const metrics = ['disk-io'];
-
-      const expectedKey = `aggregated-${Object.keys(inputs[0])[0]}`;
-      const expectedValue = inputs[0]['disk-io'] + inputs[1]['disk-io'];
-      const expectedResult = {
-        [`${expectedKey}`]: expectedValue,
-      };
-
-      const aggregatedResult = aggregate(inputs, metrics, PARAMETERS);
-
-      expect(aggregatedResult).toEqual(expectedResult);
+      const aggregatedtree = aggregate(basicTree, basicContext);
+      expect(aggregatedtree).toBeDefined();
     });
   });
 });
+
+//     it('throws error if metric is not found while aggregation.', () => {
+//       const inputs = [
+//         {
+//           'ram-util': 10,
+//         },
+//       ];
+//       const metrics = ['cpu-util'];
+
+//       const expectedMessage = METRIC_MISSING(metrics[0], 0);
+
+//       expect.assertions(1);
+
+//       try {
+//         aggregate(inputs, metrics, PARAMETERS);
+//       } catch (error) {
+//         expect(error).toEqual(new InvalidAggregationParams(expectedMessage));
+//       }
+//     });
+
+//     it('should successfully calculate avg.', () => {
+//       const inputs = [
+//         {
+//           'cpu-util': 10,
+//         },
+//         {
+//           'cpu-util': 20,
+//         },
+//       ];
+//       const metrics = ['cpu-util'];
+
+//       const expectedKey = `aggregated-${Object.keys(inputs[0])[0]}`;
+//       const expectedValue = (inputs[0]['cpu-util'] + inputs[1]['cpu-util']) / 2;
+//       const expectedResult = {
+//         [`${expectedKey}`]: expectedValue,
+//       };
+
+//       const aggregatedResult = aggregate(inputs, metrics, PARAMETERS);
+
+//       expect(aggregatedResult).toEqual(expectedResult);
+//     });
+
+//     it('should successfully calculate sum.', () => {
+//       const inputs = [
+//         {
+//           'disk-io': 10,
+//         },
+//         {
+//           'disk-io': 20,
+//         },
+//       ];
+//       const metrics = ['disk-io'];
+
+//       const expectedKey = `aggregated-${Object.keys(inputs[0])[0]}`;
+//       const expectedValue = inputs[0]['disk-io'] + inputs[1]['disk-io'];
+//       const expectedResult = {
+//         [`${expectedKey}`]: expectedValue,
+//       };
+
+//       const aggregatedResult = aggregate(inputs, metrics, PARAMETERS);
+
+//       expect(aggregatedResult).toEqual(expectedResult);
+//     });
+//   });
+// });

--- a/src/__tests__/unit/lib/impls/aggregation-test-impls.ts
+++ b/src/__tests__/unit/lib/impls/aggregation-test-impls.ts
@@ -1,0 +1,79 @@
+import {ManifestCommon} from '../../../../types/manifest';
+import {Node} from '../../../../types/compute';
+
+export const basicTree: Node = {
+  children: {
+    'child-1': {
+      pipeline: [],
+      config: {
+        'sci-e': null,
+      },
+      inputs: [
+        {
+          timestamp: '2023-08-06T00:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+        {
+          timestamp: '2023-08-06T05:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+        {
+          timestamp: '2023-08-06T10:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+      ],
+    },
+    'child-2': {
+      pipeline: [],
+      config: {
+        'sci-e': null,
+      },
+      inputs: [
+        {
+          timestamp: '2023-08-06T00:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+        {
+          timestamp: '2023-08-06T05:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+        {
+          timestamp: '2023-08-06T10:00',
+          duration: 3600,
+          energy: 0.001,
+          carbon: 10,
+        },
+      ],
+    },
+  },
+};
+
+export const basicContext: ManifestCommon = {
+  name: 'sci-e-demo',
+  description: null,
+  tags: null,
+  aggregation: {
+    metrics: ['energy', 'carbon'],
+    type: 'both',
+  },
+  initialize: {
+    plugins: {
+      'sci-e': {
+        model: 'SciE',
+        path: '@grnsft/if-models',
+      },
+    },
+  },
+};
+
+export const basicResult = {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import {ERRORS} from './util/errors';
 import {andHandle} from './util/helpers';
 import {logger} from './util/logger';
 import {saveYamlFileAs} from './util/yaml';
-
+import {aggregate} from './lib/aggregator';
 import {STRINGS} from './config';
 
 import {initalize} from './lib/initialize';
@@ -21,14 +21,13 @@ const impactEngine = async () => {
 
   if (options) {
     const {inputPath, outputPath} = options;
-
     const {tree, context, safeManifest} = await load(inputPath);
     const plugins = await initalize(context.initialize.plugins);
     const computedTree = await compute(tree, context, plugins);
-
+    const aggregatedTree = aggregate(computedTree, context);
     const outputFile = {
       ...safeManifest,
-      tree: computedTree,
+      tree: aggregatedTree,
     };
 
     if (!outputPath) {

--- a/src/lib/aggregator.ts
+++ b/src/lib/aggregator.ts
@@ -1,58 +1,144 @@
 import {ERRORS} from '../util/errors';
 import {getAggregationMethod} from '../util/param-selectors';
-
+import {PARAMETERS} from '../config';
 import {STRINGS} from '../config';
 
-import {PluginParams} from '../types/interface';
-import {Parameters} from '../types/parameters';
-import {AggregationResult} from '../types/aggregation';
-
+import {ManifestCommon} from '../types/manifest';
+import {Node} from '../types/compute';
 const {InvalidAggregationParams} = ERRORS;
-const {INVALID_AGGREGATION_METHOD, METRIC_MISSING} = STRINGS;
+const {INVALID_AGGREGATION_METHOD} = STRINGS;
 
 /**
  * Validates metrics array before applying aggregator.
  * If aggregation method is `none`, then throws error.
  */
-const checkIfMetricsAreValid = (metrics: string[], parameters: Parameters) => {
-  metrics.forEach(metric => {
-    const method = getAggregationMethod(metric, parameters);
-
+const checkIfMetricsAreValid = (context: ManifestCommon) => {
+  context.aggregation?.metrics.forEach(metric => {
+    const method = getAggregationMethod(metric, PARAMETERS);
     if (method === 'none') {
       throw new InvalidAggregationParams(INVALID_AGGREGATION_METHOD(method));
     }
   });
 };
 
-/**
- * Aggregates child node level metrics. Validates if metric aggregation type is `none`, then rejects with error.
- * Otherwise iterates over inputs by aggregating per given `metrics`.
- */
-export const aggregate = (
-  inputs: PluginParams[],
-  metrics: string[],
-  parameters: Parameters
-) => {
-  checkIfMetricsAreValid(metrics, parameters);
+/**Returns Boolean indicating whether a node has children */
+function hasChildren(node: Node) {
+  if (node['children']) {
+    return true;
+  }
+  return false;
+}
 
-  return inputs.reduce((acc, input, index) => {
-    for (const metric of metrics) {
-      if (!(metric in input)) {
-        throw new InvalidAggregationParams(METRIC_MISSING(metric, index));
+/** Returns children of given node */
+function getChildren(node: Node): Node[] {
+  const children: Node[] = [];
+  Object.keys(node.children).forEach(child => {
+    children.push(node.children[child]);
+  });
+  return children;
+}
+
+/** element-wise addition of two arrays */
+function aggregateArrays(a: Array<any>, b: Array<any>, method: string) {
+  if (method === 'sum') {
+    return a.map((element, idx) => {
+      return element + b[idx];
+    });
+  } else if (method === 'avg') {
+    return a.map((element, idx) => {
+      return (element + b[idx]) / 2;
+    });
+  }
+  return a;
+}
+
+/** aggregates multiple time series into one single time series*/
+export const aggregate = (tree: Node, context: ManifestCommon) => {
+  checkIfMetricsAreValid(context);
+  // check if root has children
+  if (hasChildren(tree)) {
+    // iterate through child nodes
+    getChildren(tree).forEach(node => {
+      // if the child has children, start recursive call to aggregate()
+      if (hasChildren(node)) {
+        aggregate(node, context);
       }
+      context.aggregation?.metrics.forEach(metric => {
+        let treeTimeSeries = tree.inputs?.map(input => input[`${metric}`]);
 
-      const accessKey = `aggregated-${metric}`;
-      acc[accessKey] = acc[accessKey] ?? 0;
-      acc[accessKey] += parseFloat(input[metric]);
-
-      /** Checks for the last iteration. */
-      if (index === inputs.length - 1) {
-        if (getAggregationMethod(metric, parameters) === 'avg') {
-          acc[accessKey] /= inputs.length;
+        if (
+          treeTimeSeries === undefined ||
+          treeTimeSeries?.includes(undefined)
+        ) {
+          treeTimeSeries = new Array(3).fill(0);
         }
-      }
-    }
 
-    return acc;
-  }, {} as AggregationResult);
+        let nodeTimeSeries = node.inputs?.map(input => input[`${metric}`]);
+
+        if (
+          nodeTimeSeries === undefined ||
+          nodeTimeSeries?.includes(undefined)
+        ) {
+          nodeTimeSeries = new Array(3).fill(0);
+        }
+
+        if (
+          context.aggregation?.type === 'both' ||
+          context.aggregation?.type === 'vertical'
+        ) {
+          if (tree[`aggregated-${metric}`]) {
+            if (node[`aggregated-${metric}`]) {
+              tree[`aggregated-${metric}`] = aggregateArrays(
+                tree[`aggregated-${metric}`],
+                node[`aggregated-${metric}`],
+                getAggregationMethod(metric, PARAMETERS)
+              );
+            } else {
+              tree[`aggregated-${metric}`] = aggregateArrays(
+                tree[`aggregated-${metric}`],
+                nodeTimeSeries,
+                getAggregationMethod(metric, PARAMETERS)
+              );
+            }
+          } else {
+            if (node[`aggregated-${metric}`]) {
+              tree[`aggregated-${metric}`] = aggregateArrays(
+                treeTimeSeries,
+                node[`aggregated-${metric}`],
+                getAggregationMethod(metric, PARAMETERS)
+              );
+            } else {
+              tree[`aggregated-${metric}`] = aggregateArrays(
+                treeTimeSeries,
+                nodeTimeSeries,
+                getAggregationMethod(metric, PARAMETERS)
+              );
+            }
+          }
+        }
+
+        if (
+          context.aggregation?.type === 'both' ||
+          context.aggregation?.type === 'horizontal'
+        ) {
+          // now do horizontal aggregation
+          tree[`total-${metric}`] = treeTimeSeries.reduce((a, b) => a + b, 0);
+          node[`total-${metric}`] = nodeTimeSeries.reduce((a, b) => a + b, 0);
+
+          if (tree[`aggregated-${metric}`]) {
+            tree[`total-aggregated-${metric}`] = tree[
+              `aggregated-${metric}`
+            ].reduce((a: number, b: number) => a + b, 0);
+          }
+          if (node[`aggregated-${metric}`]) {
+            node[`total-aggregated-${metric}`] = node[
+              `aggregated-${metric}`
+            ].reduce((a: number, b: number) => a + b, 0);
+          }
+        }
+      });
+    });
+  }
+
+  return tree;
 };

--- a/src/types/compute.ts
+++ b/src/types/compute.ts
@@ -17,4 +17,5 @@ export type Node = {
   defaults?: Record<string, any>;
   inputs?: PluginParams[];
   outputs?: PluginParams[];
+  [key: string]: any;
 };


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

Adds aggregation feature covering both vertical and horizontal aggregation.
Depending on the aggregation type defined by the user, the tree can be aggregated in vertical or horizontal mode, or both.

Vertical aggregation takes, for each metric defined in `aggregation.metrics`, the time series of observations for each child and aggregates them together, pushing the result to the parent node. If the parent node has its own data, it is aggregated too.

Horizontal aggregation takes each time series and sums the elements, giving a single representative number for the whole observation period.

If the aggregation method is `both` the following data are expected to be added to each parent node:

`total-{metric}`: the horizontally aggregated value for the parent node (not including children) (io.e. a number)
`total-aggregated-{metric}` - the horizontally aggregated value for the parent and all of its children (i.e. a number).
`aggregated-{metric}` - the vertically aggregated time series for the parent and all its children (i.e..a time series/ an array).



<!-- Make sure tests and lint pass on CI. -->

