### PR TITLE
Adds manifest that implements teads curve as a pipeline of generic plugins

### DIFF
--- a/manifests/examples/teads-curve.yml
+++ b/manifests/examples/teads-curve.yml
@@ -76,30 +76,3 @@ tree:
           duration: 360
           carbon: 30
           cpu/utilization: 100
-
-
-
-        # - timestamp: 2023-08-06T00:00
-        #   duration: 360
-        #   cpu/utilization: 1
-        #   carbon: 30
-        #   cpu/thermal-design-power: 100
-        #   cpu/energy: 0.0014087590853658538
-        # - timestamp: 2023-09-06T00:00
-        #   duration: 360
-        #   carbon: 30
-        #   cpu/utilization: 10
-        #   cpu/thermal-design-power: 100
-        #   cpu/energy: 0.0032
-        # - timestamp: 2023-10-06T00:00
-        #   duration: 360
-        #   carbon: 30
-        #   cpu/utilization: 50
-        #   cpu/thermal-design-power: 100
-        #   cpu/energy: 0.0075
-        # - timestamp: 2023-10-06T00:00
-        #   duration: 360
-        #   carbon: 30
-        #   cpu/utilization: 100
-        #   cpu/thermal-design-power: 100
-        #   cpu/energy: 0.010199999999999999

--- a/manifests/examples/teads-curve.yml
+++ b/manifests/examples/teads-curve.yml
@@ -30,6 +30,20 @@ initialize:
       global-config:
         numerator: cpu-wattage-times-duration
         denominator: 3600000
+        output: cpu-energy-raw
+    calculate-vcpu-ratio:
+      method: Divide
+      path: "builtin"
+      global-config:
+        numerator: vcpus-total
+        denominator: vcpus-allocated
+        output: vcpu-ratio
+    correct-cpu-energy-for-vcpu-ratio:
+      method: Divide
+      path: "builtin"
+      global-config:
+        numerator: cpu-energy-raw
+        denominator: vcpu-ratio
         output: cpu-energy-kwh
 tree:
   children:
@@ -39,8 +53,12 @@ tree:
         - cpu-factor-to-wattage
         - wattage-times-duration
         - wattage-to-energy-kwh
+        - calculate-vcpu-ratio
+        - correct-cpu-energy-for-vcpu-ratio
       defaults:
         thermal-design-power: 100
+        vcpus-total: 8
+        vcpus-allocated: 2
       inputs:
         - timestamp: 2023-08-06T00:00
           duration: 360

--- a/manifests/examples/teads-curve.yml
+++ b/manifests/examples/teads-curve.yml
@@ -1,0 +1,87 @@
+name: carbon-intensity plugin demo
+description: 
+tags:
+initialize:
+  plugins:
+    interpolate:
+      method: Interpolation
+      path: 'builtin'
+      global-config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+    cpu-factor-to-wattage:
+      method: Multiply
+      path: builtin
+      global-config:
+        input-parameters: ["cpu-factor", "thermal-design-power"]
+        output-parameter: "cpu-wattage"
+    wattage-times-duration:
+      method: Multiply
+      path: builtin
+      global-config:
+        input-parameters: ["cpu-wattage", "duration"]
+        output-parameter: "cpu-wattage-times-duration"
+    wattage-to-energy-kwh:
+      method: Divide
+      path: "builtin"
+      global-config:
+        numerator: cpu-wattage-times-duration
+        denominator: 3600000
+        output: cpu-energy-kwh
+tree:
+  children:
+    child:
+      pipeline:
+        - interpolate
+        - cpu-factor-to-wattage
+        - wattage-times-duration
+        - wattage-to-energy-kwh
+      defaults:
+        thermal-design-power: 100
+      inputs:
+        - timestamp: 2023-08-06T00:00
+          duration: 360
+          cpu/utilization: 1
+          carbon: 30
+        - timestamp: 2023-09-06T00:00
+          duration: 360
+          carbon: 30
+          cpu/utilization: 10
+        - timestamp: 2023-10-06T00:00
+          duration: 360
+          carbon: 30
+          cpu/utilization: 50
+        - timestamp: 2023-10-06T00:00
+          duration: 360
+          carbon: 30
+          cpu/utilization: 100
+
+
+
+        # - timestamp: 2023-08-06T00:00
+        #   duration: 360
+        #   cpu/utilization: 1
+        #   carbon: 30
+        #   cpu/thermal-design-power: 100
+        #   cpu/energy: 0.0014087590853658538
+        # - timestamp: 2023-09-06T00:00
+        #   duration: 360
+        #   carbon: 30
+        #   cpu/utilization: 10
+        #   cpu/thermal-design-power: 100
+        #   cpu/energy: 0.0032
+        # - timestamp: 2023-10-06T00:00
+        #   duration: 360
+        #   carbon: 30
+        #   cpu/utilization: 50
+        #   cpu/thermal-design-power: 100
+        #   cpu/energy: 0.0075
+        # - timestamp: 2023-10-06T00:00
+        #   duration: 360
+        #   carbon: 30
+        #   cpu/utilization: 100
+        #   cpu/thermal-design-power: 100
+        #   cpu/energy: 0.010199999999999999


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

This PR adds an example manifest that implements the Teads curve calculation from `cpu-util` to `cpu-energy` in kwh but only using our generic plugins. It matches the results from the Teads curve plugin in `if-unofficial-plugins`.



<!-- Make sure tests and lint pass on CI. -->

