### PR TITLE
Build `If-check`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@commitlint/cli": "^18.6.0",
         "@commitlint/config-conventional": "^18.6.0",
-        "@grnsft/if-core": "^0.0.9",
+        "@grnsft/if-core": "^0.0.10",
         "axios": "^1.7.2",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.4.6",
@@ -24,6 +24,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
+        "if-check": "build/check.js",
         "if-diff": "build/diff.js",
         "if-env": "build/env.js",
         "if-run": "build/index.js"
@@ -1183,9 +1184,9 @@
       }
     },
     "node_modules/@grnsft/if-core": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@grnsft/if-core/-/if-core-0.0.9.tgz",
-      "integrity": "sha512-F0niYe1j+NfhH+okz5sjP/CD7w/9BeXXe13bHkCsdOnk0WfXrq0DGKwpqh9TiLbKc9f1P3/XuojeFANMQu5nig==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@grnsft/if-core/-/if-core-0.0.10.tgz",
+      "integrity": "sha512-WHCdr7H/dFO9gT5fbjrthjOU+4RoLZ5P1F84pbGwJiKLmcU7dvYRuNQKDVIQQ7YJfZl76KSaS7sYgqA+QG8Wpw==",
       "dependencies": {
         "typescript": "^5.1.6"
       },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "bin": {
     "if-diff": "./build/diff.js",
     "if-run": "./build/index.js",
-    "if-env": "./build/env.js"
+    "if-env": "./build/env.js",
+    "if-check": "./build/check.js"
   },
   "bugs": {
     "url": "https://github.com/Green-Software-Foundation/if/issues/new?assignees=&labels=feedback&projects=&template=feedback.md&title=Feedback+-+"
@@ -17,7 +18,7 @@
   "dependencies": {
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
-    "@grnsft/if-core": "^0.0.9",
+    "@grnsft/if-core": "^0.0.10",
     "axios": "^1.7.2",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.4.6",
@@ -75,6 +76,7 @@
     "coverage": "jest --verbose --coverage --testPathPattern=src/__tests__/unit",
     "fix": "gts fix",
     "fix:package": "fixpack",
+    "if-check": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/check.ts",
     "if-diff": "npx ts-node src/diff.ts",
     "if-env": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/env.ts",
     "if-run": "npx ts-node src/index.ts",

--- a/src/__mocks__/fs/index.ts
+++ b/src/__mocks__/fs/index.ts
@@ -135,3 +135,53 @@ export const stat = async (filePath: string) => {
     throw new Error('File not found.');
   }
 };
+
+export const access = async (directoryPath: string) => {
+  if (directoryPath === 'true') {
+    return true;
+  } else {
+    throw new Error('Directory not found.');
+  }
+};
+
+export const unlink = async (filePath: string) => {
+  if (filePath === 'true') {
+    return;
+  } else {
+    throw new Error('File not found.');
+  }
+};
+
+export const readdir = (directoryPath: string) => {
+  if (directoryPath.includes('mock-empty-directory')) {
+    return [];
+  }
+
+  if (directoryPath.includes('mock-directory')) {
+    return ['file1.yaml', 'file2.yml', 'file3.txt'];
+  }
+
+  if (directoryPath.includes('mock-sub-directory')) {
+    return ['subdir/file2.yml', 'file1.yaml'];
+  }
+
+  return [];
+};
+
+export const lstat = (filePath: string) => {
+  if (
+    filePath.includes('mock-directory') ||
+    filePath.includes('mock-sub-directory/subdir')
+  ) {
+    return {
+      isDirectory: () => true,
+    };
+  }
+
+  if (filePath.includes('mock-file')) {
+    return {
+      isDirectory: () => false,
+    };
+  }
+  return;
+};

--- a/src/__mocks__/mock-manifest.yaml
+++ b/src/__mocks__/mock-manifest.yaml
@@ -1,0 +1,72 @@
+name: template manifest
+description: auto-generated template
+tags: null
+initialize:
+  plugins:
+    memory-energy-from-memory-util:
+      path: builtin
+      method: Coefficient
+      global-config:
+        input-parameter: memory/utilization
+        coefficient: 0.0001
+        output-parameter: memory/energy
+  outputs:
+    - yaml
+execution:
+  command: >-
+    /Users/manushak/.npm/_npx/1bf7c3c15bf47d04/node_modules/.bin/ts-node
+    /Users/manushak/Documents/Projects/Green-Software/if/src/index.ts -m
+    ./src/env-template.yml -o ./manifests/outputs/template
+  environment:
+    if-version: 0.4.0
+    os: macOS
+    os-version: 13.6.6
+    node-version: 20.12.2
+    date-time: 2024-06-18T08:39:55.771Z (UTC)
+    dependencies:
+      - "@babel/core@7.22.10"
+      - "@babel/preset-typescript@7.23.3"
+      - "@commitlint/cli@18.6.0"
+      - "@commitlint/config-conventional@18.6.0"
+      - "@grnsft/if-core@0.0.3"
+      - "@jest/globals@29.7.0"
+      - "@types/jest@29.5.8"
+      - "@types/js-yaml@4.0.9"
+      - "@types/luxon@3.4.2"
+      - "@types/node@20.9.0"
+      - axios-mock-adapter@1.22.0
+      - axios@1.7.2
+      - cross-env@7.0.3
+      - csv-parse@5.5.6
+      - csv-stringify@6.4.6
+      - fixpack@4.0.0
+      - gts@5.2.0
+      - husky@8.0.3
+      - jest@29.7.0
+      - js-yaml@4.1.0
+      - lint-staged@15.2.2
+      - luxon@3.4.4
+      - release-it@16.3.0
+      - rimraf@5.0.5
+      - ts-command-line-args@2.5.1
+      - ts-jest@29.1.1
+      - typescript-cubic-spline@1.0.1
+      - typescript@5.2.2
+      - winston@3.11.0
+      - zod@3.22.4
+  status: success
+tree:
+  children:
+    child:
+      pipeline:
+        - memory-energy-from-memory-util
+      config: null
+      inputs:
+        - timestamp: 2023-12-12T00:00:00.000Z
+          duration: 3600
+          memory/utilization: 10
+      outputs:
+        - timestamp: 2023-12-12T00:00:00.000Z
+          duration: 3600
+          memory/utilization: 10
+          memory/energy: 0.001

--- a/src/__tests__/unit/util/args.test.ts
+++ b/src/__tests__/unit/util/args.test.ts
@@ -7,6 +7,12 @@ jest.mock('../../../util/fs', () => ({
     }
     return false;
   },
+  isDirectoryExists: () => {
+    if (process.env.directoryExists === 'true') {
+      return true;
+    }
+    return false;
+  },
 }));
 
 jest.mock('ts-command-line-args', () => ({
@@ -70,8 +76,6 @@ jest.mock('ts-command-line-args', () => ({
       case 'diff-throw':
         throw 'mock-error';
       /** If-env mocks */
-      // case 'env-manifest-is-missing':
-      //   return;
       case 'manifest-install-provided':
         return {
           install: true,
@@ -85,6 +89,13 @@ jest.mock('ts-command-line-args', () => ({
         throw new Error('mock-error');
       case 'env-throw':
         throw 'mock-error';
+      /** If-check */
+      case 'manifest-is-provided':
+        return {manifest: 'mock-manifest.yaml'};
+      case 'directory-is-provided':
+        return {directory: '/mock-directory'};
+      case 'flags-are-not-provided':
+        return {manifest: undefined, directory: undefined};
       default:
         return {
           manifest: 'mock-manifest.yaml',
@@ -99,13 +110,19 @@ import {ERRORS} from '@grnsft/if-core/utils';
 
 import {
   parseIEProcessArgs,
+  parseIfCheckArgs,
   parseIfDiffArgs,
   parseIfEnvArgs,
 } from '../../../util/args';
 
 import {STRINGS} from '../../../config';
 
-const {CliSourceFileError, ParseCliParamsError} = ERRORS;
+const {
+  CliSourceFileError,
+  ParseCliParamsError,
+  InvalidDirectoryError,
+  MissingCliFlagsError,
+} = ERRORS;
 
 const {
   MANIFEST_IS_MISSING,
@@ -113,6 +130,8 @@ const {
   INVALID_TARGET,
   SOURCE_IS_NOT_YAML,
   MANIFEST_NOT_FOUND,
+  DIRECTORY_NOT_FOUND,
+  IF_CHECK_FLAGS_MISSING,
 } = STRINGS;
 
 describe('util/args: ', () => {
@@ -396,6 +415,103 @@ describe('util/args: ', () => {
 
       try {
         await parseIfEnvArgs();
+      } catch (error) {
+        expect(error).toEqual('mock-error');
+      }
+    });
+  });
+
+  describe('parseIfCheckArgs(): ', () => {
+    it('executes when `manifest` is provided.', async () => {
+      process.env.fileExists = 'true';
+      process.env.result = 'manifest-is-provided';
+      const response = await parseIfCheckArgs();
+
+      expect.assertions(1);
+
+      expect(response).toEqual({manifest: 'mock-manifest.yaml'});
+    });
+
+    it('executes when the `directory` is provided.', async () => {
+      process.env.directoryExists = 'true';
+      process.env.result = 'directory-is-provided';
+
+      const response = await parseIfCheckArgs();
+
+      expect.assertions(1);
+
+      expect(response).toEqual({directory: '/mock-directory'});
+    });
+
+    it('throws an error when the `directory` does not exist.', async () => {
+      process.env.directoryExists = 'false';
+      process.env.result = 'directory-is-provided';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
+      } catch (error) {
+        expect(error).toEqual(new InvalidDirectoryError(DIRECTORY_NOT_FOUND));
+      }
+    });
+
+    it('throws an error when both `manifest` and `directory` flags are not provided.', async () => {
+      process.env.result = 'flags-are-not-provided';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
+      } catch (error) {
+        expect(error).toEqual(new MissingCliFlagsError(IF_CHECK_FLAGS_MISSING));
+      }
+    });
+
+    it('throws an error if `manifest` is not a yaml.', async () => {
+      process.env.fileExists = 'true';
+      process.env.result = 'manifest-is-not-yaml';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error).toEqual(new CliSourceFileError(SOURCE_IS_NOT_YAML));
+        }
+      }
+    });
+
+    it('throws an error if `manifest` path is invalid.', async () => {
+      process.env.fileExists = 'false';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error).toEqual(new ParseCliParamsError(MANIFEST_NOT_FOUND));
+        }
+      }
+    });
+
+    it('throws an error if parsing failed.', async () => {
+      process.env.result = 'env-throw-error';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
+      } catch (error) {
+        if (error instanceof Error) {
+          expect(error).toEqual(new ParseCliParamsError('mock-error'));
+        }
+      }
+    });
+
+    it('throws error if parsing failed (not instance of error).', async () => {
+      process.env.result = 'env-throw';
+      expect.assertions(1);
+
+      try {
+        await parseIfCheckArgs();
       } catch (error) {
         expect(error).toEqual('mock-error');
       }

--- a/src/__tests__/unit/util/fs.test.ts
+++ b/src/__tests__/unit/util/fs.test.ts
@@ -5,6 +5,7 @@ import {
   isDirectoryExists,
   isFileExists,
   getYamlFiles,
+  removeFileIfExists,
 } from '../../../util/fs';
 
 jest.mock('fs/promises', () => require('../../../__mocks__/fs'));
@@ -120,6 +121,24 @@ describe('util/fs: ', () => {
         '/mock-sub-directory/file1.yaml',
       ]);
       expect(fsReaddirSpy).toHaveBeenCalledWith('/mock-directory');
+    });
+  });
+
+  describe('removeFileIfExists(): ', () => {
+    it('successfully delete file if exists.', async () => {
+      await isFileExists('true');
+      const result = await removeFileIfExists('mock-path');
+
+      expect.assertions(1);
+      expect(result).toEqual(undefined);
+    });
+
+    it('does not throw an error if the file not exists.', async () => {
+      await isFileExists('false');
+      const result = await removeFileIfExists('mock-path');
+
+      expect.assertions(1);
+      expect(result).toEqual(undefined);
     });
   });
 });

--- a/src/__tests__/unit/util/helpers.test.ts
+++ b/src/__tests__/unit/util/helpers.test.ts
@@ -146,7 +146,6 @@ import {
   getOptionsFromArgs,
   addTemplateManifest,
   initializeAndInstallLibs,
-  logStdoutFailMessage,
 } from '../../../util/helpers';
 import {CONFIG} from '../../../config';
 import {Difference} from '../../../types/lib/compare';
@@ -665,18 +664,6 @@ description: mock-description
       expect(mockExit).toHaveBeenCalledTimes(1);
 
       process.exit = originalProcessExit;
-    });
-  });
-
-  describe('logStdoutFailMessage(): ', () => {
-    it('successfully logs the failed message.', () => {
-      const errorMessage = {stdout: '\n\nmock error message'};
-      const logSpy = jest.spyOn(global.console, 'log');
-      logStdoutFailMessage(errorMessage);
-
-      expect.assertions(1);
-
-      expect(logSpy).toHaveBeenCalledWith('mock error message');
     });
   });
 });

--- a/src/__tests__/unit/util/helpers.test.ts
+++ b/src/__tests__/unit/util/helpers.test.ts
@@ -146,6 +146,7 @@ import {
   getOptionsFromArgs,
   addTemplateManifest,
   initializeAndInstallLibs,
+  logStdoutFailMessage,
 } from '../../../util/helpers';
 import {CONFIG} from '../../../config';
 import {Difference} from '../../../types/lib/compare';
@@ -664,6 +665,23 @@ description: mock-description
       expect(mockExit).toHaveBeenCalledTimes(1);
 
       process.exit = originalProcessExit;
+    });
+  });
+
+  describe('logStdoutFailMessage(): ', () => {
+    it('successfully logs the failed message.', () => {
+      const errorMessage = {stdout: '\n\nmock error message'};
+      const mockFilename = 'mock-filename.yaml';
+      const logSpy = jest.spyOn(global.console, 'log');
+      logStdoutFailMessage(errorMessage, mockFilename);
+
+      expect.assertions(2);
+
+      expect(logSpy).toHaveBeenCalledWith(
+        `if-check could not verify ${mockFilename}. The re-executed file does not match the original.\n`
+      );
+
+      expect(logSpy).toHaveBeenCalledWith('mock error message');
     });
   });
 });

--- a/src/__tests__/unit/util/helpers.test.ts
+++ b/src/__tests__/unit/util/helpers.test.ts
@@ -146,7 +146,7 @@ import {
   getOptionsFromArgs,
   addTemplateManifest,
   initializeAndInstallLibs,
-  // initializeAndInstallLibs,
+  logStdoutFailMessage,
 } from '../../../util/helpers';
 import {CONFIG} from '../../../config';
 import {Difference} from '../../../types/lib/compare';
@@ -665,6 +665,18 @@ description: mock-description
       expect(mockExit).toHaveBeenCalledTimes(1);
 
       process.exit = originalProcessExit;
+    });
+  });
+
+  describe('logStdoutFailMessage(): ', () => {
+    it('successfully logs the failed message.', () => {
+      const errorMessage = {stdout: '\n\nmock error message'};
+      const logSpy = jest.spyOn(global.console, 'log');
+      logStdoutFailMessage(errorMessage);
+
+      expect.assertions(1);
+
+      expect(logSpy).toHaveBeenCalledWith('mock error message');
     });
   });
 });

--- a/src/__tests__/unit/util/npm.test.ts
+++ b/src/__tests__/unit/util/npm.test.ts
@@ -266,7 +266,9 @@ describe('util/npm: ', () => {
       expect(spyExecPromise).toHaveBeenCalledWith(command, {
         cwd: process.cwd(),
       });
-      expect(logSpy).toHaveBeenCalledWith('Files match!\n');
+      expect(logSpy).toHaveBeenCalledWith(
+        'if-check successfully verified <mock-manifest.yaml>\n'
+      );
 
       const packageJsonPath = 'src/__mocks__/package.json';
       fsSync.unlink(path.resolve(process.cwd(), reManifest), () => {});

--- a/src/__tests__/unit/util/npm.test.ts
+++ b/src/__tests__/unit/util/npm.test.ts
@@ -21,6 +21,7 @@ import {
   updatePackageJsonDependencies,
   extractPathsWithVersion,
   updatePackageJsonProperties,
+  executeCommands,
 } from '../../../util/npm';
 import {isFileExists} from '../../../util/fs';
 
@@ -176,7 +177,7 @@ describe('util/npm: ', () => {
         '@commitlint/cli@18.6.0',
         '@commitlint/config-conventional@18.6.0',
         '@grnsft/if-core@0.0.7',
-        '@grnsft/if-plugins@v0.3.2 extraneous -> file:../../../if-models',
+        '@grnsft/if-plugins@v0.3.2',
         '@grnsft/if-unofficial-plugins@v0.3.0 extraneous -> file:../../../if-unofficial-models',
         '@jest/globals@29.7.0',
       ];
@@ -245,5 +246,31 @@ describe('util/npm: ', () => {
 
       expect(fsReadSpy).toHaveBeenCalledWith(packageJsonPath, 'utf8');
     });
+  });
+
+  describe('executeCommands(): ', () => {
+    it('successfully executes with correct commands.', async () => {
+      const manifest = './src/__mocks__/mock-manifest.yaml';
+      const reManifest = 'src/__mocks__/re-mock-manifest.yaml';
+      const command = `npm run if-env -- -m ${manifest} && npm run if-run -- -m ${manifest} -o ${reManifest.replace(
+        '.yaml',
+        ''
+      )} &&  node -p 'Boolean(process.stdout.isTTY)' | npm run if-diff -- -s ${reManifest} -t ${manifest}`;
+      const logSpy = jest.spyOn(global.console, 'log');
+      const spyExecPromise = jest.spyOn(helpers, 'execPromise');
+      jest.spyOn(fs, 'unlink').mockResolvedValue();
+
+      await executeCommands(manifest, false);
+
+      expect.assertions(2);
+      expect(spyExecPromise).toHaveBeenCalledWith(command, {
+        cwd: process.cwd(),
+      });
+      expect(logSpy).toHaveBeenCalledWith('Files match!\n');
+
+      const packageJsonPath = 'src/__mocks__/package.json';
+      fsSync.unlink(path.resolve(process.cwd(), reManifest), () => {});
+      fsSync.unlink(path.resolve(process.cwd(), packageJsonPath), () => {});
+    }, 70000);
   });
 });

--- a/src/__tests__/unit/util/npm.test.ts
+++ b/src/__tests__/unit/util/npm.test.ts
@@ -252,20 +252,13 @@ describe('util/npm: ', () => {
     it('successfully executes with correct commands.', async () => {
       const manifest = './src/__mocks__/mock-manifest.yaml';
       const reManifest = 'src/__mocks__/re-mock-manifest.yaml';
-      const command = `npm run if-env -- -m ${manifest} && npm run if-run -- -m ${manifest} -o ${reManifest.replace(
-        '.yaml',
-        ''
-      )} &&  node -p 'Boolean(process.stdout.isTTY)' | npm run if-diff -- -s ${reManifest} -t ${manifest}`;
       const logSpy = jest.spyOn(global.console, 'log');
-      const spyExecPromise = jest.spyOn(helpers, 'execPromise');
+
       jest.spyOn(fs, 'unlink').mockResolvedValue();
 
       await executeCommands(manifest, false);
 
-      expect.assertions(2);
-      expect(spyExecPromise).toHaveBeenCalledWith(command, {
-        cwd: process.cwd(),
-      });
+      expect.assertions(1);
       expect(logSpy).toHaveBeenCalledWith(
         'if-check successfully verified mock-manifest.yaml\n'
       );

--- a/src/__tests__/unit/util/npm.test.ts
+++ b/src/__tests__/unit/util/npm.test.ts
@@ -267,7 +267,7 @@ describe('util/npm: ', () => {
         cwd: process.cwd(),
       });
       expect(logSpy).toHaveBeenCalledWith(
-        'if-check successfully verified <mock-manifest.yaml>\n'
+        'if-check successfully verified mock-manifest.yaml\n'
       );
 
       const packageJsonPath = 'src/__mocks__/package.json';

--- a/src/check.ts
+++ b/src/check.ts
@@ -25,7 +25,9 @@ const IfCheck = async () => {
       await executeCommands(manifest, false);
     } catch (error: any) {
       const fileName = path.basename(manifest);
-      const executedFile = manifest.replace(fileName, `re-${fileName}`);
+      const executedFile = manifest
+        .replace(fileName, `re-${fileName}`)
+        .replace('yml', 'yaml');
       const manifestDirPath = path.dirname(manifest);
 
       logStdoutFailMessage(error);
@@ -45,7 +47,9 @@ const IfCheck = async () => {
         await executeCommands(file, true);
       } catch (error: any) {
         const fileName = path.basename(file);
-        const executedFile = file.replace(fileName, `re-${fileName}`);
+        const executedFile = file
+          .replace(fileName, `re-${fileName}`)
+          .replace('yml', 'yaml');
 
         logStdoutFailMessage(error);
         await fs.unlink(executedFile);

--- a/src/check.ts
+++ b/src/check.ts
@@ -5,13 +5,12 @@ import * as path from 'path';
 
 import {logger} from './util/logger';
 import {parseIfCheckArgs} from './util/args';
-import {logStdoutFailMessage} from './util/helpers';
 import {getYamlFiles} from './util/fs';
 
 import {STRINGS} from './config';
 import {executeCommands} from './util/npm';
 
-const {CHECKING} = STRINGS;
+const {CHECKING, IF_CHECK_FAILED} = STRINGS;
 
 const IfCheck = async () => {
   const commandArgs = await parseIfCheckArgs();
@@ -30,7 +29,7 @@ const IfCheck = async () => {
         .replace('yml', 'yaml');
       const manifestDirPath = path.dirname(manifest);
 
-      logStdoutFailMessage(error);
+      console.log(IF_CHECK_FAILED(fileName));
 
       await fs.unlink(`${manifestDirPath}/package.json`);
       await fs.unlink(executedFile);
@@ -51,7 +50,7 @@ const IfCheck = async () => {
           .replace(fileName, `re-${fileName}`)
           .replace('yml', 'yaml');
 
-        logStdoutFailMessage(error);
+        console.log(IF_CHECK_FAILED(fileName));
         await fs.unlink(executedFile);
       }
     }

--- a/src/check.ts
+++ b/src/check.ts
@@ -4,13 +4,14 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import {logger} from './util/logger';
+import {logStdoutFailMessage} from './util/helpers';
 import {parseIfCheckArgs} from './util/args';
 import {getYamlFiles} from './util/fs';
 
 import {STRINGS} from './config';
 import {executeCommands} from './util/npm';
 
-const {CHECKING, IF_CHECK_FAILED} = STRINGS;
+const {CHECKING} = STRINGS;
 
 const IfCheck = async () => {
   const commandArgs = await parseIfCheckArgs();
@@ -29,7 +30,7 @@ const IfCheck = async () => {
         .replace('yml', 'yaml');
       const manifestDirPath = path.dirname(manifest);
 
-      console.log(IF_CHECK_FAILED(fileName));
+      logStdoutFailMessage(error, fileName);
 
       await fs.unlink(`${manifestDirPath}/package.json`);
       await fs.unlink(executedFile);
@@ -50,7 +51,8 @@ const IfCheck = async () => {
           .replace(fileName, `re-${fileName}`)
           .replace('yml', 'yaml');
 
-        console.log(IF_CHECK_FAILED(fileName));
+        logStdoutFailMessage(error, fileName);
+
         await fs.unlink(executedFile);
       }
     }

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/* eslint-disable no-process-exit */
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+import {logger} from './util/logger';
+import {parseIfCheckArgs} from './util/args';
+import {logStdoutFailMessage} from './util/helpers';
+import {getYamlFiles} from './util/fs';
+
+import {STRINGS} from './config';
+import {executeCommands} from './util/npm';
+
+const {CHECKING} = STRINGS;
+
+const IfCheck = async () => {
+  const commandArgs = await parseIfCheckArgs();
+
+  console.log(`${CHECKING}\n`);
+
+  if (commandArgs.manifest) {
+    const manifest = commandArgs.manifest;
+
+    try {
+      await executeCommands(manifest, false);
+    } catch (error: any) {
+      const fileName = path.basename(manifest);
+      const executedFile = manifest.replace(fileName, `re-${fileName}`);
+      const manifestDirPath = path.dirname(manifest);
+
+      logStdoutFailMessage(error);
+
+      await fs.unlink(`${manifestDirPath}/package.json`);
+      await fs.unlink(executedFile);
+    }
+  } else {
+    const directory = commandArgs.directory;
+    const files = await getYamlFiles(directory!);
+
+    for await (const file of files) {
+      const fileName = path.basename(file);
+      console.log(fileName);
+
+      try {
+        await executeCommands(file, true);
+      } catch (error: any) {
+        const fileName = path.basename(file);
+        const executedFile = file.replace(fileName, `re-${fileName}`);
+
+        logStdoutFailMessage(error);
+        await fs.unlink(executedFile);
+      }
+    }
+  }
+};
+
+IfCheck().catch(error => {
+  if (error instanceof Error) {
+    logger.error(error);
+    process.exit(2);
+  }
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,12 @@ import {ArgumentConfig, ParseOptions} from 'ts-command-line-args';
 
 import {STRINGS} from './strings';
 
-import {IFDiffArgs, IEArgs, IFEnvArgs} from '../types/process-args';
+import {
+  IFDiffArgs,
+  IEArgs,
+  IFEnvArgs,
+  IFCheckArgs,
+} from '../types/process-args';
 
 const {DISCLAIMER_MESSAGE} = STRINGS;
 
@@ -119,6 +124,31 @@ export const CONFIG = {
     FAILURE_MESSAGE_TEMPLATE:
       'Faied to create the environment with the template manifest!',
     FAILURE_MESSAGE_DEPENDENCIES: 'Manifest dependencies are not available!',
+  },
+  IF_CHECK: {
+    ARGS: {
+      manifest: {
+        type: String,
+        optional: true,
+        alias: 'm',
+        description: '[path to the manifest file]',
+      },
+      directory: {
+        type: String,
+        optional: true,
+        alias: 'd',
+        description: '[path to the manifests directory]',
+      },
+    } as ArgumentConfig<IFCheckArgs>,
+    HELP: {
+      helpArg: 'help',
+      headerContentSections: [
+        {header: 'Impact Framework', content: 'IF-Check Helpful keywords:'},
+      ],
+      footerContentSections: [
+        {header: 'Green Software Foundation', content: DISCLAIMER_MESSAGE},
+      ],
+    } as ParseOptions<any>,
   },
   GITHUB_PATH: 'https://github.com',
   NATIVE_PLUGIN: 'if-plugins',

--- a/src/config/strings.ts
+++ b/src/config/strings.ts
@@ -136,4 +136,8 @@ ${error}`,
   IF_CHECK_FLAGS_MISSING:
     'Either the `--manifest` or `--directory` command should be provided with a path',
   DIRECTORY_NOT_FOUND: 'Directory not found.',
+  IF_CHECK_FAILED: (filename: string) =>
+    `if-check could not verify <${filename}>. The re-executed file does not match the original.\n`,
+  IF_CHECK_VERIFIED: (filename: string) =>
+    `if-check successfully verified <${filename}>\n`,
 };

--- a/src/config/strings.ts
+++ b/src/config/strings.ts
@@ -137,7 +137,7 @@ ${error}`,
     'Either the `--manifest` or `--directory` command should be provided with a path',
   DIRECTORY_NOT_FOUND: 'Directory not found.',
   IF_CHECK_FAILED: (filename: string) =>
-    `if-check could not verify <${filename}>. The re-executed file does not match the original.\n`,
+    `if-check could not verify ${filename}. The re-executed file does not match the original.\n`,
   IF_CHECK_VERIFIED: (filename: string) =>
-    `if-check successfully verified <${filename}>\n`,
+    `if-check successfully verified ${filename}\n`,
 };

--- a/src/config/strings.ts
+++ b/src/config/strings.ts
@@ -132,4 +132,8 @@ ${error}`,
     `Exporting to csv file: ${savepath}`,
   EXPORTING_RAW_CSV_FILE: (savepath: string) =>
     `Exporting raw csv file: ${savepath}`,
+  CHECKING: 'Checking...',
+  IF_CHECK_FLAGS_MISSING:
+    'Either the `--manifest` or `--directory` command should be provided with a path',
+  DIRECTORY_NOT_FOUND: 'Directory not found.',
 };

--- a/src/config/strings.ts
+++ b/src/config/strings.ts
@@ -138,6 +138,8 @@ ${error}`,
   IF_CHECK_FLAGS_MISSING:
     'Either the `--manifest` or `--directory` command should be provided with a path',
   DIRECTORY_NOT_FOUND: 'Directory not found.',
+  DIRECTORY_YAML_FILES_NOT_FOUND:
+    'The directory does not contain any YAML/YML files.\n',
   IF_CHECK_FAILED: (filename: string) =>
     `if-check could not verify ${filename}. The re-executed file does not match the original.\n`,
   IF_CHECK_VERIFIED: (filename: string) =>

--- a/src/types/process-args.ts
+++ b/src/types/process-args.ts
@@ -17,6 +17,11 @@ export interface IFEnvArgs {
   cwd?: boolean;
 }
 
+export interface IFCheckArgs {
+  manifest?: string;
+  directory?: string;
+}
+
 export interface Options {
   outputPath?: string;
   stdout?: boolean;

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -57,3 +57,12 @@ export const getFileName = (filePath: string) => {
   const extension = path.extname(filePath);
   return baseName.replace(extension, '');
 };
+
+/**
+ * Removes the given file if exists.
+ */
+export const removeFileIfExists = async (filePath: string) => {
+  if (await isFileExists(filePath)) {
+    await fs.unlink(filePath);
+  }
+};

--- a/src/util/fs.ts
+++ b/src/util/fs.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as path from 'path';
 
 /**
  * Checks if file exists with the given `filePath`.
@@ -22,4 +23,37 @@ export const isDirectoryExists = async (directoryPath: string) => {
   } catch (error) {
     return false;
   }
+};
+
+/**
+ * Gets all files that have either .yml or .yaml extension in the given directory.
+ */
+export const getYamlFiles = async (directory: string) => {
+  let yamlFiles: string[] = [];
+
+  const files = await fs.readdir(directory);
+
+  for (const file of files) {
+    const fullPath = path.join(directory, file);
+    const stat = await fs.lstat(fullPath);
+
+    if (stat.isDirectory()) {
+      yamlFiles = yamlFiles.concat(await getYamlFiles(fullPath));
+    } else {
+      if (file.endsWith('.yml') || file.endsWith('.yaml')) {
+        yamlFiles.push(fullPath);
+      }
+    }
+  }
+
+  return yamlFiles;
+};
+
+/**
+ * Gets fileName from the given path without an extension.
+ */
+export const getFileName = (filePath: string) => {
+  const baseName = path.basename(filePath);
+  const extension = path.extname(filePath);
+  return baseName.replace(extension, '');
 };

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -268,3 +268,14 @@ export const addTemplateManifest = async (destinationDir: string) => {
     process.exit(1);
   }
 };
+
+/**
+ * Logs the failure message from the stdout of an error.
+ */
+export const logStdoutFailMessage = (error: any) => {
+  const stdout = error.stdout;
+  const logs = stdout.split('\n\n');
+  const failMessage = logs[logs.length - 1];
+
+  console.log(failMessage);
+};

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -268,14 +268,3 @@ export const addTemplateManifest = async (destinationDir: string) => {
     process.exit(1);
   }
 };
-
-/**
- * Logs the failure message from the stdout of an error.
- */
-export const logStdoutFailMessage = (error: any) => {
-  const stdout = error.stdout;
-  const logs = stdout.split('\n\n');
-  const failMessage = logs[logs.length - 1];
-
-  console.log(failMessage);
-};

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -33,7 +33,7 @@ const {
   FAILURE_MESSAGE_DEPENDENCIES,
 } = IF_ENV;
 
-const {UNSUPPORTED_ERROR} = STRINGS;
+const {UNSUPPORTED_ERROR, IF_CHECK_FAILED} = STRINGS;
 const {MissingPluginDependenciesError} = ERRORS;
 
 /**
@@ -267,4 +267,17 @@ export const addTemplateManifest = async (destinationDir: string) => {
     console.log(FAILURE_MESSAGE_TEMPLATE);
     process.exit(1);
   }
+};
+
+/**
+ * Logs the failure message from the stdout of an error.
+ */
+export const logStdoutFailMessage = (error: any, fileName: string) => {
+  console.log(IF_CHECK_FAILED(fileName));
+
+  const stdout = error.stdout;
+  const logs = stdout.split('\n\n');
+  const failMessage = logs[logs.length - 1];
+
+  console.log(failMessage);
 };

--- a/src/util/npm.ts
+++ b/src/util/npm.ts
@@ -12,7 +12,8 @@ import {ManifestPlugin, PathWithVersion} from '../types/npm';
 
 const packageJson = require('../../package.json');
 
-const {INITIALIZING_PACKAGE_JSON, INSTALLING_NPM_PACKAGES} = STRINGS;
+const {INITIALIZING_PACKAGE_JSON, INSTALLING_NPM_PACKAGES, IF_CHECK_VERIFIED} =
+  STRINGS;
 
 /**
  * Checks if the package.json is exists, if not, initializes it.
@@ -164,7 +165,7 @@ export const executeCommands = async (manifest: string, cwd: boolean) => {
   } -s ${executedManifest}.yaml -t ${manifest}`;
   const ttyCommand = " node -p 'Boolean(process.stdout.isTTY)'";
 
-  const result = await execPromise(
+  await execPromise(
     `${ifEnvCommand} && ${ifRunCommand} && ${ttyCommand} | ${ifDiffCommand}`,
     {
       cwd: process.env.CURRENT_DIR || process.cwd(),
@@ -177,10 +178,5 @@ export const executeCommands = async (manifest: string, cwd: boolean) => {
 
   await fs.unlink(`${executedManifest}.yaml`);
 
-  if (result.stdout) {
-    const logs = result.stdout.split('\n\n');
-    const successMessage = logs[logs.length - 1];
-
-    console.log(successMessage);
-  }
+  console.log(IF_CHECK_VERIFIED(path.basename(manifest)));
 };

--- a/src/util/npm.ts
+++ b/src/util/npm.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import {execPromise} from './helpers';
-import {isDirectoryExists, isFileExists} from './fs';
+import {isDirectoryExists, getFileName, isFileExists} from './fs';
 import {logger} from './logger';
 
 import {STRINGS} from '../config';
@@ -143,4 +143,44 @@ export const updatePackageJsonProperties = async (
     newPackageJsonPath,
     JSON.stringify(newPackageJson, null, 2)
   );
+};
+
+/**
+ * Executes a series of npm commands based on the provided manifest file.
+ */
+export const executeCommands = async (manifest: string, cwd: boolean) => {
+  // TODO: After release remove isGlobal and appropriate checks
+  const isGlobal = !!process.env.npm_config_global;
+  const manifestDirPath = path.dirname(manifest);
+  const manifestFileName = getFileName(manifest);
+  const executedManifest = path.join(manifestDirPath, `re-${manifestFileName}`);
+  const ifEnv = `${isGlobal ? 'if-env' : 'npm run if-env --'} -m ${manifest}`;
+  const ifEnvCommand = cwd ? `${ifEnv} -c` : ifEnv;
+  const ifRunCommand = `${
+    isGlobal ? 'if-run' : 'npm run if-run --'
+  } -m ${manifest} -o ${executedManifest}`;
+  const ifDiffCommand = `${
+    isGlobal ? 'if-diff' : 'npm run if-diff --'
+  } -s ${executedManifest}.yaml -t ${manifest}`;
+  const ttyCommand = " node -p 'Boolean(process.stdout.isTTY)'";
+
+  const result = await execPromise(
+    `${ifEnvCommand} && ${ifRunCommand} && ${ttyCommand} | ${ifDiffCommand}`,
+    {
+      cwd: process.env.CURRENT_DIR || process.cwd(),
+    }
+  );
+
+  if (!cwd) {
+    await fs.unlink(`${manifestDirPath}/package.json`);
+  }
+
+  await fs.unlink(`${executedManifest}.yaml`);
+
+  if (result.stdout) {
+    const logs = result.stdout.split('\n\n');
+    const successMessage = logs[logs.length - 1];
+
+    console.log(successMessage);
+  }
 };


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
-  Add functionality to check if the provided manifest outputs are correct
- There are 2 cases to test:
- When you provide manifest file path: `npm run if-check — -m ./manifests/outputs/manifest.yaml`. If the outputs are the same as the generated manifest file, it should print `Files match!` or  
`Files do not match!
tree.children.child.outputs.0.cpu/energy
source: 0.08333333333333333
target: 0.1`
- When you provide a directory path where placed manifests files are: `npm run if-check — -d ./manifests/output/`. It should print every file name with the execution result
- 


<!-- Make sure tests and lint pass on CI. -->

