### PR TITLE
user-defined upsampling resolution

### DIFF
--- a/src/__tests__/if-run/builtins/time-sync.test.ts
+++ b/src/__tests__/if-run/builtins/time-sync.test.ts
@@ -19,7 +19,8 @@ const {
 } = ERRORS;
 
 const {
-  INVALID_UPSAMPLING_RESOLUTION,
+  INCOMPATIBLE_RESOLUTION_WITH_INTERVAL,
+  INCOMPATIBLE_RESOLUTION_WITH_GAPS,
   INVALID_OBSERVATION_OVERLAP,
   INVALID_TIME_NORMALIZATION,
   AVOIDING_PADDING_BY_EDGES,
@@ -964,7 +965,7 @@ describe('builtins/time-sync:', () => {
           ]);
         } catch (error) {
           expect(error).toStrictEqual(
-            new ConfigError(INVALID_UPSAMPLING_RESOLUTION)
+            new ConfigError(INCOMPATIBLE_RESOLUTION_WITH_INTERVAL)
           );
         }
       });
@@ -989,7 +990,7 @@ describe('builtins/time-sync:', () => {
           ]);
         } catch (error) {
           expect(error).toStrictEqual(
-            new ConfigError(INVALID_UPSAMPLING_RESOLUTION)
+            new ConfigError(INCOMPATIBLE_RESOLUTION_WITH_GAPS)
           );
         }
       });
@@ -1017,7 +1018,7 @@ describe('builtins/time-sync:', () => {
           ]);
         } catch (error) {
           expect(error).toStrictEqual(
-            new ConfigError(INVALID_UPSAMPLING_RESOLUTION)
+            new ConfigError(INCOMPATIBLE_RESOLUTION_WITH_GAPS)
           );
         }
       });

--- a/src/if-run/builtins/time-sync/index.ts
+++ b/src/if-run/builtins/time-sync/index.ts
@@ -33,7 +33,9 @@ const {
 } = ERRORS;
 
 const {
-  INVALID_UPSAMPLING_RESOLUTION,
+  INCOMPATIBLE_RESOLUTION_WITH_INTERVAL,
+  INCOMPATIBLE_RESOLUTION_WITH_GAPS,
+  INCOMPATIBLE_RESOLUTION_WITH_INPUTS,
   INVALID_TIME_NORMALIZATION,
   INVALID_OBSERVATION_OVERLAP,
   AVOIDING_PADDING_BY_EDGES,
@@ -105,7 +107,8 @@ export const TimeSync = (
     };
     validateIntervalForResample(
       timeParams.interval,
-      timeParams.upsamplingResolution
+      timeParams.upsamplingResolution,
+      INCOMPATIBLE_RESOLUTION_WITH_INTERVAL
     );
     const pad = checkForPadding(inputs, timeParams);
     validatePadding(pad, timeParams);
@@ -145,7 +148,8 @@ export const TimeSync = (
 
           validateIntervalForResample(
             input.duration,
-            timeParams.upsamplingResolution
+            timeParams.upsamplingResolution,
+            INCOMPATIBLE_RESOLUTION_WITH_INPUTS
           );
 
           if (timelineGapSize > 1) {
@@ -189,9 +193,13 @@ export const TimeSync = (
   /**
    * Checks if a given duration is compatible with a given timeStep. If not, throws an error
    */
-  const validateIntervalForResample = (duration: number, timeStep: number) => {
+  const validateIntervalForResample = (
+    duration: number,
+    timeStep: number,
+    errorMessage: string
+  ) => {
     if (duration % timeStep !== 0) {
-      throw new ConfigError(INVALID_UPSAMPLING_RESOLUTION);
+      throw new ConfigError(errorMessage);
     }
   };
 
@@ -560,7 +568,8 @@ export const TimeSync = (
     const array: PluginParams[] = [];
     validateIntervalForResample(
       params.endDate.diff(params.startDate).as('seconds'),
-      params.timeStep
+      params.timeStep,
+      INCOMPATIBLE_RESOLUTION_WITH_GAPS
     );
     const dateRange = Interval.fromDateTimes(params.startDate, params.endDate);
 

--- a/src/if-run/config/strings.ts
+++ b/src/if-run/config/strings.ts
@@ -10,6 +10,8 @@ export const STRINGS = {
     `Provided module \`${path}\` is invalid or not found. ${error ?? ''}
 `,
   INVALID_TIME_NORMALIZATION: 'Start time or end time is missing.',
+  INVALID_UPSAMPLING_RESOLUTION:
+    'Upsampling resolution does not adhere to all constraints',
   UNEXPECTED_TIME_CONFIG:
     'Unexpected node-level config provided for time-sync plugin.',
   INVALID_TIME_INTERVAL: 'Interval is missing.',

--- a/src/if-run/config/strings.ts
+++ b/src/if-run/config/strings.ts
@@ -10,8 +10,12 @@ export const STRINGS = {
     `Provided module \`${path}\` is invalid or not found. ${error ?? ''}
 `,
   INVALID_TIME_NORMALIZATION: 'Start time or end time is missing.',
-  INVALID_UPSAMPLING_RESOLUTION:
-    'Upsampling resolution does not adhere to all constraints',
+  INCOMPATIBLE_RESOLUTION_WITH_INTERVAL:
+    'The upsampling resolution must be a divisor of the given interval, but the provided value does not satisfy this criteria.',
+  INCOMPATIBLE_RESOLUTION_WITH_INPUTS:
+    'The upsampling resolution must be a divisor of all inputs durations, but the provided values do not satisfy this criteria.',
+  INCOMPATIBLE_RESOLUTION_WITH_GAPS:
+    'The upsampling resolution must be a divisor of gaps and paddings in the time-series, but the provided values do not satisfy this criteria.',
   UNEXPECTED_TIME_CONFIG:
     'Unexpected node-level config provided for time-sync plugin.',
   INVALID_TIME_INTERVAL: 'Interval is missing.',

--- a/src/if-run/types/time-sync.ts
+++ b/src/if-run/types/time-sync.ts
@@ -5,6 +5,7 @@ export type TimeNormalizerConfig = {
   'end-time': Date | string;
   interval: number;
   'allow-padding': boolean;
+  'upsampling-resolution'?: number;
 };
 
 export type PaddingReceipt = {
@@ -17,4 +18,5 @@ export type TimeParams = {
   endTime: DateTime;
   interval: number;
   allowPadding: boolean;
+  upsamplingResolution: number;
 };


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
Added the possibility to provide a custom upsampling resolution to time-sync in the model config.
- If no upsampling resolution is provided, it defaults to `1s`
- If upsampling resolution does not meet criteria a `Config Error` is thrown.


<!-- Make sure tests and lint pass on CI. -->

