### PR TITLE
Fix the if-merge output manifest name when the `output` ends with `\`

### DIFF
--- a/src/if-merge/util/helpers.ts
+++ b/src/if-merge/util/helpers.ts
@@ -64,6 +64,10 @@ const saveMergedManifest = async (
   context: Context,
   outputPath: string | undefined
 ) => {
+  if (outputPath?.endsWith('/')) {
+    outputPath += 'merged-manifest';
+  }
+
   const output = {
     outputPath,
     noOutput: false,


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- 
- 


<!-- Make sure tests and lint pass on CI. -->

