### PR TITLE
fix(src): fix osInfo

### DIFF
--- a/src/__tests__/if-run/util/os-checker.test.ts
+++ b/src/__tests__/if-run/util/os-checker.test.ts
@@ -10,7 +10,7 @@ jest.mock('os', () => ({
   release: () => 'm.m.m',
 }));
 jest.mock('../../../common/util/helpers', () => ({
-  execPromise: async () => {
+  execFilePromise: async () => {
     if (process.env.KIND === 'darwin' && process.env.REJECT === 'true')
       return {
         stdout: '',
@@ -37,10 +37,8 @@ BuildVersion:     23D60
     if (process.env.KIND === 'linux') {
       return {
         stdout: `
-Distributor ID: Ubuntu
-Description:    Ubuntu 22.04.4 LTS
-Release:        22.04
-Codename:       jammy
+Distributor ID:\tUbuntu
+Description:\tUbuntu 22.04.4 LTS
       `,
       };
     }
@@ -48,8 +46,9 @@ Codename:       jammy
     if (process.env.KIND === 'win32') {
       return {
         stdout: `
-OS Name:                   Microsoft Windows 11 Enterprise
-OS Version:                10.0.22631 N/A Build 22631
+Caption     : Microsoft Windows 11 Enterprise\r
+Version     : 10.0.22631\r
+BuildNumber : 22631\r
       `,
       };
     }

--- a/src/common/util/helpers.ts
+++ b/src/common/util/helpers.ts
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /* eslint-disable no-process-exit */
 import {createInterface} from 'node:readline/promises';
-import {exec, execFileSync} from 'child_process';
+import {exec, execFile, execFileSync} from 'child_process';
 import * as path from 'path';
 import {promisify} from 'util';
 
 /**
- * Promise version of Node's `exec` from `child-process`.
+ * Promise version of Node's `exec` and `execFile` from `child-process`.
  */
 export const execPromise = promisify(exec);
+export const execFilePromise = promisify(execFile);
 
 /**
  * Prepends process path to given `filePath`.


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
In `getLinuxInfo`, `lsb_release -a` was used, but since the separator in this command's output is a tab character rather than a space, the output was not retrieved correctly.
Additionally, since `getLinuxInfo` only needed Distributor ID and Description, the option was changed from -a to -id.

cf. https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/lsbrelease.html

In `getWindowsInfo`, `systeminfo` was used, but its output is affected by the current code page.  As a result, in non-English environments, the output could not be retrieved correctly, leading to errors.  This was fixed by using PowerShell's `Get-WmiObject`, ensuring correct retrieval regardless of the current code page.  Additionally, an extra CR (\r) at the end of the name was removed.

Furthermore, `getLinuxInfo`, `getWindowsInfo`, and `getMacVersion` all used `execPromise`, but since a shell is not necessary to execute these commands, a new `execFilePromise` was created and used instead.

<!-- Make sure tests and lint pass on CI. -->

