### PR TITLE
fix(src): fix help output when installed globally

### DIFF
--- a/src/__tests__/common/util/helpers.test.ts
+++ b/src/__tests__/common/util/helpers.test.ts
@@ -58,7 +58,6 @@ describe('common/util/helpers: ', () => {
   });
 
   describe('runHelpCommand(): ', () => {
-    const originalEnv = process.env;
     it('calls process.exit with code 1 on error.', () => {
       expect.assertions(3);
 
@@ -69,37 +68,12 @@ describe('common/util/helpers: ', () => {
 
       expect(() => runHelpCommand('if-run')).toThrow('process.exit(1) called');
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-run', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });
-
-    it('executes when the script runs from the global.', () => {
-      expect.assertions(3);
-      process.env.npm_config_global = 'true';
-
-      jest.spyOn(process, 'exit').mockImplementation((code?: number) => {
-        expect(code).toEqual(1);
-        throw new Error(`process.exit(${code}) called`);
-      });
-
-      expect(() => runHelpCommand('if-run')).toThrow('process.exit(1) called');
-      expect(execFileSync).toHaveBeenCalledWith(
-        'if-run',
-        ['--silent', '--', '-h'],
-        {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
-          stdio: 'inherit',
-          shell: false,
-        }
-      );
-    });
-
-    process.env = originalEnv;
   });
 });

--- a/src/__tests__/if-check/util/args.test.ts
+++ b/src/__tests__/if-check/util/args.test.ts
@@ -177,12 +177,10 @@ describe('if-check/util: ', () => {
       );
 
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-check', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/__tests__/if-csv/util/args.test.ts
+++ b/src/__tests__/if-csv/util/args.test.ts
@@ -121,12 +121,10 @@ describe('util/args: ', () => {
       await expect(parseIfCsvArgs()).rejects.toThrow('process.exit(1) called');
 
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-csv', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/__tests__/if-diff/util/args.test.ts
+++ b/src/__tests__/if-diff/util/args.test.ts
@@ -128,12 +128,10 @@ describe('util/args: ', () => {
       expect(() => parseIfDiffArgs()).toThrow('process.exit(1) called');
 
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-diff', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/__tests__/if-env/util/args.test.ts
+++ b/src/__tests__/if-env/util/args.test.ts
@@ -119,12 +119,10 @@ describe('util/args: ', () => {
       await expect(parseIfEnvArgs()).rejects.toThrow('process.exit(1) called');
 
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-env', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/__tests__/if-merge/util/args.test.ts
+++ b/src/__tests__/if-merge/util/args.test.ts
@@ -159,12 +159,10 @@ describe('if-merge/util/args: ', () => {
       );
 
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-merge', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/__tests__/if-run/util/args.test.ts
+++ b/src/__tests__/if-run/util/args.test.ts
@@ -122,12 +122,10 @@ describe('if-run/util/args: ', () => {
 
       expect(() => parseIfRunProcessArgs()).toThrow('process.exit(1) called');
       expect(execFileSync).toHaveBeenCalledWith(
-        'npm',
-        ['run', 'if-run', '--silent', '--', '-h'],
+        process.execPath,
+        [...process.execArgv, process.argv[1], '-h'],
         {
-          cwd: process.env.CURRENT_DIR || process.cwd(),
           stdio: 'inherit',
-          shell: false,
         }
       );
     });

--- a/src/common/util/helpers.ts
+++ b/src/common/util/helpers.ts
@@ -73,18 +73,8 @@ export const parseManifestFromStdin = async () => {
 export const runHelpCommand = (command: string) => {
   console.log(`Here are the supported flags for the \`${command}\` command:`);
 
-  const isGlobal = !!process.env.npm_config_global;
-  const ifCommand = [
-    isGlobal ? command : 'npm',
-    ...(isGlobal ? ['--silent'] : ['run', command, '--silent']),
-    '--',
-    '-h',
-  ];
-
-  execFileSync(ifCommand[0], ifCommand.slice(1), {
-    cwd: process.env.CURRENT_DIR || process.cwd(),
+  execFileSync(process.execPath, [...process.execArgv, process.argv[1], '-h'], {
     stdio: 'inherit',
-    shell: false,
   });
 
   process.exit(1);


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
Fix an issue where the help message was not displayed correctly when an incorrect command argument was provided (e.g., `if-run -x`) in a globally installed environment.

The following is a sample output when running `if-run -x`.
```
$ sudo npm install -g @grnsft/if

added 249 packages in 9s

38 packages are looking for funding
  run `npm fund` for details
$ if-run -x
Unknown option: -x
Here are the supported flags for the `if-run` command:
[2025-03-18 01:30:01.630 AM] Error:     Command failed: npm run if-run --silent -- -h
    at checkExecSyncError (node:child_process:890:11)
    at execFileSync (node:child_process:926:15)
    at runHelpCommand (/usr/local/lib/node_modules/@grnsft/if/build/common/util/helpers.js:94:38)
    at validateAndParseProcessArgs (/usr/local/lib/node_modules/@grnsft/if/build/if-run/util/args.js:25:42)
    at parseIfRunProcessArgs (/usr/local/lib/node_modules/@grnsft/if/build/if-run/util/args.js:38:100)
    at impactEngine (/usr/local/lib/node_modules/@grnsft/if/build/if-run/index.js:21:54)
    at Object.<anonymous> (/usr/local/lib/node_modules/@grnsft/if/build/if-run/index.js:57:1)
    at Module._compile (node:internal/modules/cjs/loader:1356:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1414:10)

[2025-03-18 01:30:01.633 AM] error:     UnsupportedErrorClass: plugin threw error class: Error that is not recognized by Impact Framework

$ npm_config_global=true if-run -x
Unknown option: -x
Here are the supported flags for the `if-run` command:
Unknown option: --silent
Here are the supported flags for the `if-run` command:
Unknown option: --silent
...
(continue indefinitely)
```


<!-- Make sure tests and lint pass on CI. -->
Just in case, I ran `npm run if-check -- -d manifests/outputs` and confirmed that there were no changes.