### PR TITLE
fix(src): fix if-check

### DIFF
--- a/src/__tests__/if-check/util/npm.test.ts
+++ b/src/__tests__/if-check/util/npm.test.ts
@@ -1,4 +1,4 @@
-jest.mock('fs/promises', () => require('../../../__mocks__/fs'));
+import * as path from 'path';
 
 const mockInfo = jest.fn();
 
@@ -11,76 +11,13 @@ jest.mock('../../../common/util/logger', () => ({
   },
 }));
 
+const mockExecFileSync = jest.fn();
+
 jest.mock('child_process', () => {
   const originalModule = jest.requireActual('child_process');
   return {
     ...originalModule,
-    execFileSync: (file: any, args: any) => {
-      switch (process.env.NPM_INSTALL) {
-        case 'true':
-          expect(file).toEqual('npm install @grnsft/if@0.3.3-beta.0');
-          break;
-        case 'npm init -y':
-          expect(file).toEqual('npm init -y');
-          break;
-        case 'if-check':
-          expect(
-            [
-              'npm run if-env -- -m ./src/__mocks__/mock-manifest.yaml',
-              'npm run if-run -- -m ./src/__mocks__/mock-manifest.yaml -o src/__mocks__/re-mock-manifest',
-              'node -p Boolean(process.stdout.isTTY)',
-              'npm run if-diff -- -s src/__mocks__/re-mock-manifest.yaml -t ./src/__mocks__/mock-manifest.yaml',
-            ].includes(
-              Array.isArray(args) ? `${file} ${args.join(' ')}` : file.trim()
-            )
-          ).toBeTruthy();
-          break;
-        case 'if-check-prefix':
-          expect(
-            [
-              'npm run if-env -- --prefix=.. -m ./src/__mocks__/mock-manifest.yaml',
-              'npm run if-run -- --prefix=.. -m ./src/__mocks__/mock-manifest.yaml -o src/__mocks__/re-mock-manifest',
-              'npm run if-diff -- --prefix=.. -s src/__mocks__/re-mock-manifest.yaml -t ./src/__mocks__/mock-manifest.yaml',
-              'node -p Boolean(process.stdout.isTTY)',
-            ].includes(
-              Array.isArray(args) ? `${file} ${args.join(' ')}` : file.trim()
-            )
-          ).toBeTruthy();
-          break;
-        case 'if-check-global':
-          expect(
-            [
-              'if-env  -m ./src/__mocks__/mock-manifest.yaml',
-              'if-run  -m ./src/__mocks__/mock-manifest.yaml -o src/__mocks__/re-mock-manifest',
-              'if-diff  -s src/__mocks__/re-mock-manifest.yaml -t ./src/__mocks__/mock-manifest.yaml',
-              'node -p Boolean(process.stdout.isTTY)',
-            ].includes(
-              Array.isArray(args) ? `${file} ${args.join(' ')}` : file.trim()
-            )
-          ).toBeTruthy();
-
-          break;
-        case 'if-check-tty':
-          expect(
-            [
-              'if-env  -m ./src/__mocks__/mock-manifest.yaml',
-              'if-run  -m ./src/__mocks__/mock-manifest.yaml -o src/__mocks__/re-mock-manifest',
-              'if-diff  -s src/__mocks__/re-mock-manifest.yaml -t ./src/__mocks__/mock-manifest.yaml',
-              'tty | if-diff  -s src/__mocks__/re-mock-manifest.yaml -t ./src/__mocks__/mock-manifest.yaml',
-              'node -p Boolean(process.stdout.isTTY)',
-            ].includes(
-              Array.isArray(args) ? `${file} ${args.join(' ')}` : file.trim()
-            )
-          ).toBeTruthy();
-
-          break;
-      }
-
-      if (process.env.NPM_INSTALL === 'if-check-tty') {
-        return true;
-      }
-      return;
-    },
+    execFileSync: mockExecFileSync,
   };
 });
 
@@ -88,75 +25,262 @@ import {executeCommands} from '../../../if-check/util/npm';
 
 describe('if-check/util/npm: ', () => {
   const originalEnv = process.env;
+  const originalArgv1 = process.argv[1];
+  const logSpy = jest.spyOn(global.console, 'log');
+
   describe('executeCommands(): ', () => {
     beforeEach(() => {
       jest.clearAllMocks();
+      process.env = {...originalEnv};
     });
 
     afterEach(() => {
       process.env = originalEnv;
+      process.argv[1] = originalArgv1;
     });
 
     it('successfully executes with correct commands.', async () => {
-      process.env.NPM_INSTALL = 'if-check';
+      process.argv[1] = '/path/to/if-check/index.js';
       const manifest = './src/__mocks__/mock-manifest.yaml';
-      const logSpy = jest.spyOn(global.console, 'log');
 
       await executeCommands(manifest);
 
-      expect.assertions(6);
+      const manifestPath = path.resolve(manifest);
+      const executedManifest = path.resolve('src/__mocks__/re-mock-manifest');
+
+      expect.assertions(5);
       expect(logSpy).toHaveBeenCalledWith(
         '✔ if-check successfully verified mock-manifest.yaml\n'
+      );
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        process.execPath,
+        [...process.execArgv, '/path/to/if-env', '-m', manifestPath],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-run',
+          '-m',
+          manifestPath,
+          '-o',
+          executedManifest,
+        ],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        3,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-diff',
+          '-s',
+          `${executedManifest}.yaml`,
+          '-t',
+          manifestPath,
+        ],
+        {stdio: 'inherit'}
       );
     });
 
-    it('successfully executes with prefix.', async () => {
-      process.env.CURRENT_DIR = 'mock-dir';
-      process.env.NPM_INSTALL = 'if-check-prefix';
-      const manifest = './src/__mocks__/mock-manifest.yaml';
-      const logSpy = jest.spyOn(global.console, 'log');
+    it('successfully executes with env-var CURRENT_DIR.', async () => {
+      process.env.CURRENT_DIR = path.resolve('src');
+      process.argv[1] = '/path/to/if-check/index.js';
+      const manifest = './__mocks__/mock-manifest.yaml';
 
       await executeCommands(manifest);
 
-      expect.assertions(6);
+      const manifestPath = path.resolve(process.env.CURRENT_DIR!, manifest);
+      const executedManifest = path.resolve(
+        process.env.CURRENT_DIR!,
+        '__mocks__/re-mock-manifest'
+      );
+
+      expect.assertions(5);
       expect(logSpy).toHaveBeenCalledWith(
         '✔ if-check successfully verified mock-manifest.yaml\n'
       );
-      delete process.env.CURRENT_DIR;
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        process.execPath,
+        [...process.execArgv, '/path/to/if-env', '-m', manifestPath],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-run',
+          '-m',
+          manifestPath,
+          '-o',
+          executedManifest,
+        ],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        3,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-diff',
+          '-s',
+          `${executedManifest}.yaml`,
+          '-t',
+          manifestPath,
+        ],
+        {stdio: 'inherit'}
+      );
     });
 
-    it('successfully executes when it runs from the global.', async () => {
-      process.env.NPM_INSTALL = 'if-check-global';
-      process.env.npm_config_global = 'true';
-
+    it('successfully executes if the entry-point ends with /index.ts.', async () => {
+      process.argv[1] = '/path/to/if-check/index.ts';
       const manifest = './src/__mocks__/mock-manifest.yaml';
-      const logSpy = jest.spyOn(global.console, 'log');
 
       await executeCommands(manifest);
 
-      expect.assertions(6);
+      const manifestPath = path.resolve(manifest);
+      const executedManifest = path.resolve('src/__mocks__/re-mock-manifest');
+
+      expect.assertions(5);
       expect(logSpy).toHaveBeenCalledWith(
         '✔ if-check successfully verified mock-manifest.yaml\n'
+      );
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        process.execPath,
+        [...process.execArgv, '/path/to/if-env', '-m', manifestPath],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-run',
+          '-m',
+          manifestPath,
+          '-o',
+          executedManifest,
+        ],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        3,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-diff',
+          '-s',
+          `${executedManifest}.yaml`,
+          '-t',
+          manifestPath,
+        ],
+        {stdio: 'inherit'}
       );
     });
 
-    it('successfully executes when the `tty` is true.', async () => {
-      const originalIsTTY = process.stdin.isTTY;
-      process.stdin.isTTY = true;
-      process.env.NPM_INSTALL = 'if-check-tty';
-      process.env.npm_config_global = 'true';
-
+    it('successfully executes if the entry-point without extension.', async () => {
+      process.argv[1] = '/path/to/if-check/index';
       const manifest = './src/__mocks__/mock-manifest.yaml';
-      const logSpy = jest.spyOn(global.console, 'log');
 
       await executeCommands(manifest);
 
-      expect.assertions(6);
+      const manifestPath = path.resolve(manifest);
+      const executedManifest = path.resolve('src/__mocks__/re-mock-manifest');
+
+      expect.assertions(5);
       expect(logSpy).toHaveBeenCalledWith(
         '✔ if-check successfully verified mock-manifest.yaml\n'
       );
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        process.execPath,
+        [...process.execArgv, '/path/to/if-env', '-m', manifestPath],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-run',
+          '-m',
+          manifestPath,
+          '-o',
+          executedManifest,
+        ],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        3,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-diff',
+          '-s',
+          `${executedManifest}.yaml`,
+          '-t',
+          manifestPath,
+        ],
+        {stdio: 'inherit'}
+      );
+    });
 
-      process.stdin.isTTY = originalIsTTY;
+    it('successfully executes if the entry-point without /index.[jt]s.', async () => {
+      process.argv[1] = '/path/to/if-check';
+      const manifest = './src/__mocks__/mock-manifest.yaml';
+
+      await executeCommands(manifest);
+
+      const manifestPath = path.resolve(manifest);
+      const executedManifest = path.resolve('src/__mocks__/re-mock-manifest');
+
+      expect.assertions(5);
+      expect(logSpy).toHaveBeenCalledWith(
+        '✔ if-check successfully verified mock-manifest.yaml\n'
+      );
+      expect(mockExecFileSync).toHaveBeenCalledTimes(3);
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        1,
+        process.execPath,
+        [...process.execArgv, '/path/to/if-env', '-m', manifestPath],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        2,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-run',
+          '-m',
+          manifestPath,
+          '-o',
+          executedManifest,
+        ],
+        {stdio: 'ignore'}
+      );
+      expect(mockExecFileSync).toHaveBeenNthCalledWith(
+        3,
+        process.execPath,
+        [
+          ...process.execArgv,
+          '/path/to/if-diff',
+          '-s',
+          `${executedManifest}.yaml`,
+          '-t',
+          manifestPath,
+        ],
+        {stdio: 'inherit'}
+      );
     });
   });
 });

--- a/src/if-check/index.ts
+++ b/src/if-check/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-process-exit */
 import * as path from 'path';
 
-import {getYamlFiles, removeFileIfExists} from '../common/util/fs';
+import {getYamlFiles} from '../common/util/fs';
 import {debugLogger} from '../common/util/debug-logger';
 import {logger} from '../common/util/logger';
 
@@ -35,15 +35,7 @@ const IfCheck = async () => {
       await executeCommands(manifest);
     } catch (error: any) {
       const fileName = path.basename(manifest);
-      const executedFile = manifest
-        .replace(fileName, `re-${fileName}`)
-        .replace('yml', 'yaml');
-      const manifestDirPath = path.dirname(manifest);
-
       logStdoutFailMessage(error, fileName);
-
-      await removeFileIfExists(`${manifestDirPath}/package.json`);
-      await removeFileIfExists(executedFile);
     }
   } else {
     const failedLogs = {count: 0, message: ''};
@@ -66,15 +58,9 @@ const IfCheck = async () => {
         await executeCommands(file);
       } catch (error: any) {
         const fileName = path.basename(file);
-        const executedFile = file
-          .replace(fileName, `re-${fileName}`)
-          .replace('yml', 'yaml');
-
         const failedFilesLog = logStdoutFailMessage(error, fileName);
         failedLogs.message = failedLogs.message.concat(failedFilesLog);
         failedLogs.count++;
-
-        await removeFileIfExists(executedFile);
       }
     }
 

--- a/src/if-check/util/npm.ts
+++ b/src/if-check/util/npm.ts
@@ -1,115 +1,69 @@
 import * as path from 'node:path';
-import {execFileSync} from 'child_process';
+import {execFileSync, type ExecFileSyncOptions} from 'child_process';
 import {getFileName, removeFileIfExists} from '../../common/util/fs';
 import {STRINGS} from '../config';
 
 const {IF_CHECK_VERIFIED} = STRINGS;
 
 /**
- * Escapes shell characters that could be dangerous in a command.
+ * Executes a single Impact Framework command.
  */
-const escapeShellArg = (str: string) => str.replace(/([`$\\&;|*?<>])/g, '\\$1');
+const executeCommand = (
+  command: string,
+  args: readonly string[],
+  executionOptions: ExecFileSyncOptions
+) => {
+  const commandPath = process.argv[1].replace(
+    /(?<=[/\\])if-check(?:[/\\]index(?:\.[jt]s)?)?$/,
+    command
+  );
+
+  return execFileSync(
+    process.execPath,
+    [...process.execArgv, commandPath, ...args],
+    executionOptions
+  );
+};
 
 /**
- * Executes a series of npm commands based on the provided manifest file.
+ * Executes a series of Impact Framework commands based on the provided manifest file.
  */
 export const executeCommands = async (manifest: string) => {
-  // Determine if the npm command should be run globally
-  const isGlobal = !!process.env.npm_config_global;
+  // Get fullpath of the manifest
+  if (!path.isAbsolute(manifest)) {
+    manifest = path.resolve(process.env.CURRENT_DIR || process.cwd(), manifest);
+  }
   // Get the directory path and file name of the manifest
   const manifestDirPath = path.dirname(manifest);
   const manifestFileName = getFileName(manifest);
   // Create a path for the executed manifest file
   const executedManifest = path.join(manifestDirPath, `re-${manifestFileName}`);
 
-  // Determine the prefix flag if the CURRENT_DIR environment variable is set and different from the current working directory
-  const prefixFlag =
-    process.env.CURRENT_DIR && process.env.CURRENT_DIR !== process.cwd()
-      ? `--prefix=${path.relative(process.env.CURRENT_DIR!, process.cwd())}`
-      : '';
+  try {
+    // Execute the if-env command
+    executeCommand('if-env', ['-m', manifest], {
+      stdio: 'ignore',
+    });
 
-  // Escape shell characters in the manifest paths
-  const sanitizedManifest = escapeShellArg(manifest);
-  const sanitizedExecutedManifest = escapeShellArg(executedManifest);
+    // Execute the if-run command
+    executeCommand('if-run', ['-m', manifest, '-o', executedManifest], {
+      stdio: 'ignore',
+    });
 
-  // Construct the if-env command
-  const ifEnvCommand = [
-    isGlobal ? 'if-env' : 'npm',
-    ...(isGlobal ? [] : ['run', 'if-env']),
-    isGlobal ? '' : '--',
-    ...(prefixFlag === '' ? [] : [prefixFlag]),
-    '-m',
-    sanitizedManifest,
-  ];
-
-  // Construct the if-run command
-  const ifRunCommand = [
-    isGlobal ? 'if-run' : 'npm',
-    ...(isGlobal ? [] : ['run', 'if-run']),
-    isGlobal ? '' : '--',
-    ...(prefixFlag === '' ? [] : [prefixFlag]),
-    '-m',
-    sanitizedManifest,
-    '-o',
-    sanitizedExecutedManifest,
-  ];
-
-  // Construct the tty command to check if the process is running in a TTY context
-  const ttyCommand = ['node', '-p', 'Boolean(process.stdout.isTTY)'];
-
-  // Construct the if-diff command
-  const ifDiffCommand = [
-    isGlobal ? 'if-diff' : 'npm',
-    ...(isGlobal ? [] : ['run', 'if-diff']),
-    isGlobal ? '' : '--',
-    ...(prefixFlag === '' ? [] : [prefixFlag]),
-    '-s',
-    `${sanitizedExecutedManifest}.yaml`,
-    '-t',
-    sanitizedManifest,
-  ];
-
-  const executionOptions = {
-    cwd: process.env.CURRENT_DIR || process.cwd(),
-  };
-
-  // Execute the if-env command
-  execFileSync(ifEnvCommand[0], ifEnvCommand.slice(1), {
-    ...executionOptions,
-    shell: true,
-  });
-
-  // Execute the if-run command
-  execFileSync(ifRunCommand[0], ifRunCommand.slice(1), executionOptions);
-
-  // Execute the tty command to check if the process is running in a TTY context
-  execFileSync(ttyCommand[0], ttyCommand.slice(1), executionOptions);
-
-  // Get the result of the tty command
-  const ttyResult = execFileSync(
-    ttyCommand[0],
-    ttyCommand.slice(1),
-    executionOptions
-  );
-
-  // Determine if the process is running in a TTY context
-  const tty = ttyResult && ttyResult.toString().trim();
-  // Construct the full command to execute if-diff, optionally piping through tty
-  const fullCommand = `${tty === 'true' ? 'tty |' : ''} ${ifDiffCommand.join(
-    ' '
-  )}`;
-
-  // Execute the full command
-  execFileSync(fullCommand, {
-    ...executionOptions,
-    stdio: 'inherit',
-    shell: true,
-  });
-
-  // Remove the package.json file if it exists
-  await removeFileIfExists(`${manifestDirPath}/package.json`);
-  // Remove the executed manifest file if it exists
-  await removeFileIfExists(`${executedManifest}.yaml`);
+    // Execute the if-diff command
+    executeCommand(
+      'if-diff',
+      ['-s', `${executedManifest}.yaml`, '-t', manifest],
+      {
+        stdio: 'inherit',
+      }
+    );
+  } finally {
+    // Remove the package.json file if it exists
+    await removeFileIfExists(`${manifestDirPath}/package.json`);
+    // Remove the executed manifest file if it exists
+    await removeFileIfExists(`${executedManifest}.yaml`);
+  }
 
   console.log(IF_CHECK_VERIFIED(path.basename(manifest)));
 };


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

### A description of the changes proposed in the Pull Request
Fix the following issues with `if-check`:

- Does not work properly when executed from outside the project root directory.
- Does not work properly when executed from a globally installed instance.
- `package.json` remains when an error occurs during execution with `-d` option.


The following is a sample output when running `if-check` outside the project root directory.

```
$ cd manifests/outputs
$ npm run if-check -- -d builtins/csv-import/

> @grnsft/if@1.0.1 if-check
> cross-env CURRENT_DIR=$(node -p "process.env.INIT_CWD") npx ts-node src/if-check/index.ts -d builtins/csv-import/

[2025-04-24 09:14:30.102 PM] InvalidDirectoryError:     Directory not found.
    at parseIfCheckArgs (/home/mitsuru/if/src/if-check/util/args.ts:66:13)
    at async IfCheck (/home/mitsuru/if/src/if-check/index.ts:27:23)
```


The following is a sample output when running `if-check`.

```
$ if-check -m if/manifests/outputs/pipelines/sci.yaml
Checking...

npm error code ENOENT
npm error syscall open
npm error path /home/mitsuru/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/home/mitsuru/package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: /home/mitsuru/.npm/_logs/2025-04-24T11_55_36_487Z-debug-0.log
✖ if-check could not verify sci.yaml. The re-executed file does not match the original.

Command failed: npm run if-env -- -m if/manifests/outputs/pipelines/sci.yaml
npm error code ENOENT
npm error syscall open
npm error path /home/mitsuru/package.json
npm error errno -2
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/home/mitsuru/package.json'
npm error enoent This is related to npm not being able to find a file.
npm error enoent
npm error A complete log of this run can be found in: /home/mitsuru/.npm/_logs/2025-04-24T11_55_36_487Z-debug-0.log


$ npm_config_global=true if-check -m if/manifests/outputs/pipelines/sci.yaml
Checking...

✖ if-check could not verify sci.yaml. The re-executed file does not match the original.
```


The following is a sample output when an error occurs in `if-check`.

```
$ cd manifests/outputs
$ ls -lFA builtins/csv-import/
total 4
-rw-r--r-- 1 mitsuru mitsuru 2269 Mar 16 00:40 success.yaml
$ npm_config_global=true if-check -d builtins/csv-import/
Checking...

Executing `builtins/csv-import/success.yaml`
✖ if-check could not verify success.yaml. The re-executed file does not match the original.


---------
if-check verification failures:

Executing `success.yaml`
✖
---------
Check summary:
0 of 1 files are passed.

$ ls -lFA builtins/csv-import/
total 8
-rw-r--r-- 1 mitsuru mitsuru  606 Apr 24 21:45 package.json
-rw-r--r-- 1 mitsuru mitsuru 2269 Mar 16 00:40 success.yaml
$
```

<!-- Make sure tests and lint pass on CI. -->
Just in case, I ran `npm run if-check -- -d manifests/outputs` and confirmed that there were no changes.