### PR TITLE
fix(src): fix getProcessStartingTimestamp function

### DIFF
--- a/src/if-run/lib/environment.ts
+++ b/src/if-run/lib/environment.ts
@@ -1,5 +1,3 @@
-import {DateTime} from 'luxon';
-
 import {osInfo} from '../util/os-checker';
 import {execPromise} from '../../common/util/helpers';
 import {Manifest} from '../../common/types/manifest';
@@ -12,24 +10,20 @@ const packageJson = require('../../../package.json');
 const {CAPTURING_RUNTIME_ENVIRONMENT_DATA} = STRINGS;
 
 /**
- * 1. Gets the high-resolution real time when the application starts.
- * 2. Converts the high-resolution time to milliseconds.
+ * 1. Gets the process uptime (the number of seconds the current Node.js process has been running).
+ * 2. Converts the uptime to milliseconds.
  * 3. Gets the current DateTime.
  * 4. Subtracts the milliseconds from the current DateTime.
  */
 const getProcessStartingTimestamp = () => {
-  const startTime = process.hrtime();
+  const seconds = process.uptime();
+  const milliseconds = seconds * 1000;
 
-  const [seconds, nanoseconds] = process.hrtime(startTime);
-  const milliseconds = seconds * 1000 + nanoseconds / 1e6;
+  const currentDateTime = Date.now();
 
-  const currentDateTime = DateTime.local();
+  const applicationStartDateTime = currentDateTime - milliseconds;
 
-  const applicationStartDateTime = currentDateTime.minus({
-    milliseconds: milliseconds,
-  });
-
-  return applicationStartDateTime.toUTC().toString();
+  return new Date(applicationStartDateTime).toISOString();
 };
 
 /**


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.

### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
The `getProcessStartingTimestamp` function was using hrtime but wasn't correctly calculating the process start time.
Therefore, modify it to use uptime for the calculation instead.

Additionally, change it to use the standard `Date` object instead of luxon, as the rich features provided by luxon weren't necessary.

Note: When `hrtime` is called without arguments, it returns the elapsed time from some point (not specified in the API), rather than returning the value of the process start time.

<!-- Make sure tests and lint pass on CI. -->

