### PR TITLE
fix(src): fix DivisionByZero message

### DIFF
--- a/src/__tests__/if-run/builtins/divide.test.ts
+++ b/src/__tests__/if-run/builtins/divide.test.ts
@@ -274,6 +274,7 @@ describe('builtins/divide: ', () => {
     });
 
     it('throws an error when `denominator` is 0.', async () => {
+      const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
       const config = {
         numerator: 'vcpus-allocated',
         denominator: 0,
@@ -281,7 +282,7 @@ describe('builtins/divide: ', () => {
       };
       const divide = Divide(config, parametersMetadata, {});
 
-      expect.assertions(1);
+      expect.assertions(3);
 
       const response = await divide.execute([
         {
@@ -299,6 +300,11 @@ describe('builtins/divide: ', () => {
           'vcpus-allocated-per-second': 24,
         },
       ]);
+
+      expect(mockConsoleWarn).toHaveBeenCalled();
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '-- SKIPPING -- DivisionByZero: you are attempting to divide by zero in Divide plugin : inputs[0]\n'
+      );
     });
 
     it('throws an error when `denominator` is string.', async () => {

--- a/src/__tests__/if-run/builtins/sci.test.ts
+++ b/src/__tests__/if-run/builtins/sci.test.ts
@@ -206,6 +206,7 @@ describe('builtins/sci:', () => {
     });
 
     it('fallbacks to carbon value, if functional unit is 0.', async () => {
+      const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
       const config = {'functional-unit': 'requests'};
       const sci = Sci(config, parametersMetadata, {});
       const inputs = [
@@ -220,9 +221,14 @@ describe('builtins/sci:', () => {
       ];
       const result = await sci.execute(inputs);
 
-      expect.assertions(1);
+      expect.assertions(3);
 
       expect(result).toStrictEqual([{...inputs[0], sci: inputs[0].carbon}]);
+
+      expect(mockConsoleWarn).toHaveBeenCalled();
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '-- SKIPPING -- DivisionByZero: you are attempting to divide by zero in Sci plugin : inputs[0]\n'
+      );
     });
 
     it('throws an error on missing config.', async () => {

--- a/src/if-run/builtins/divide/index.ts
+++ b/src/if-run/builtins/divide/index.ts
@@ -79,7 +79,7 @@ const calculateDivide = (
     typeof numerator === 'number' ? numerator : input[numerator];
 
   if (finalDenominator === 0) {
-    console.warn(ZERO_DIVISION(Divide.name, index));
+    console.warn(ZERO_DIVISION('Divide', index));
     return finalNumerator;
   }
 

--- a/src/if-run/builtins/sci/index.ts
+++ b/src/if-run/builtins/sci/index.ts
@@ -92,7 +92,7 @@ export const Sci = PluginFactory({
         : config['functional-unit'];
 
       if (functionalUnit === 0) {
-        console.warn(ZERO_DIVISION(Sci.name, index));
+        console.warn(ZERO_DIVISION('Sci', index));
 
         return {
           ...input,


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
When outputting DivisionByZero messages, module names were also being output, using `Divide.name` and `Sci.name` as the module names.
However, since `Divide` and `Sci` are anonymous functions, they don't have the `name` property, and therefore module names weren't being output.

<!-- Make sure tests and lint pass on CI. -->

