### PR TITLE
fix(src): fix error in if-run when devDeps are not installed

### DIFF
--- a/src/if-run/lib/environment.ts
+++ b/src/if-run/lib/environment.ts
@@ -44,11 +44,11 @@ const flattenDependencies = (dependencies: [string, PackageDependency][]) =>
   });
 
 /**
- * 1. Runs `npm list --json`.
+ * 1. Runs `npm list --json --omit=dev`.
  * 2. Parses json data and converts to list.
  */
 const listDependencies = async () => {
-  const {stdout} = await execPromise('npm list --json');
+  const {stdout} = await execPromise('npm list --json --omit=dev');
   const npmListResponse: NpmListResponse = JSON.parse(stdout);
 
   if (npmListResponse.dependencies) {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
If `devDependencies` are not installed, the `npm list --json` command will result in an error, causing `if-run` to fail.
To avoid this, add `--omit=dev` to the command.


<!-- Make sure tests and lint pass on CI. -->
How to reproduce:

```sh
# uninstall devDependencies
$ npm prune --omit=dev

up to date, audited 252 packages in 4s

33 packages are looking for funding
  run `npm fund` for details

  found 0 vulnerabilities
# execute if-run
$ node build/if-run -m manifests/examples/pipelines/sci.yml
[2025-05-11 12:23:11.646 PM] info:
Graduated Project

This project is a Graduated Project, supported by the Green Software Foundation. The publicly available version documented in the README is trusted by the GSF. New versions of the project may be released, or it may move to the Maintained or Retired Stage at any moment.

[2025-05-11 12:23:12.585 PM] Error:     Command failed: npm list --json
npm ERR! code ELSPROBLEMS
npm ERR! missing: @babel/core@^7.22.10, required by @grnsft/if@1.0.1
npm ERR! missing: @babel/preset-typescript@^7.22.5, required by @grnsft/if@1.0.1
npm ERR! missing: @jest/globals@^29.6.1, required by @grnsft/if@1.0.1
npm ERR! missing: @types/jest@^29.5.7, required by @grnsft/if@1.0.1
npm ERR! missing: @types/js-yaml@^4.0.5, required by @grnsft/if@1.0.1
npm ERR! missing: @types/luxon@^3.4.2, required by @grnsft/if@1.0.1
npm ERR! missing: axios-mock-adapter@^1.22.0, required by @grnsft/if@1.0.1
npm ERR! missing: cross-env@7.0.3, required by @grnsft/if@1.0.1
npm ERR! missing: fixpack@^4.0.0, required by @grnsft/if@1.0.1
npm ERR! missing: gts@^5.0.0, required by @grnsft/if@1.0.1
npm ERR! missing: husky@^8.0.0, required by @grnsft/if@1.0.1
npm ERR! missing: jest@^29.6.1, required by @grnsft/if@1.0.1
npm ERR! missing: lint-staged@^15.2.2, required by @grnsft/if@1.0.1
npm ERR! missing: release-it@^16.3.0, required by @grnsft/if@1.0.1
npm ERR! missing: rimraf@^5.0.5, required by @grnsft/if@1.0.1
npm ERR! missing: ts-jest@^29.1.1, required by @grnsft/if@1.0.1

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/mitsuru/.npm/_logs/2025-05-11T03_23_12_143Z-debug-0.log

    at ChildProcess.exithandler (node:child_process:422:12)
    at ChildProcess.emit (node:events:517:28)
    at maybeClose (node:internal/child_process:1098:16)
    at ChildProcess._handle.onexit (node:internal/child_process:303:5)

[2025-05-11 12:23:12.586 PM] error:     UnsupportedErrorClass: plugin threw error class: Error that is not recognized by Impact Framework
```
