### PR TITLE
test(src): fix test for parseManifestFromStdin

### DIFF
--- a/src/__tests__/common/util/helpers.test.ts
+++ b/src/__tests__/common/util/helpers.test.ts
@@ -22,10 +22,13 @@ import {
 describe('common/util/helpers: ', () => {
   describe('parseManifestFromStdin(): ', () => {
     it('returns empty string if there is no data in stdin.', async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = false;
       const response = await parseManifestFromStdin();
       const expectedResult = '';
 
       expect(response).toEqual(expectedResult);
+      process.stdin.isTTY = originalIsTTY;
     });
 
     it('returns empty string if nothing is piped.', async () => {
@@ -39,21 +42,27 @@ describe('common/util/helpers: ', () => {
     });
 
     it('throws error if there is no manifest in stdin.', async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = false;
       process.env.readline = 'no_manifest';
       expect.assertions(1);
 
       const response = await parseManifestFromStdin();
 
       expect(response).toEqual('');
+      process.stdin.isTTY = originalIsTTY;
     });
 
     it('returns empty string if there is no data in stdin.', async () => {
+      const originalIsTTY = process.stdin.isTTY;
+      process.stdin.isTTY = false;
       process.env.readline = 'manifest';
       const response = await parseManifestFromStdin();
       const expectedMessage =
         '\nname: mock-name\ndescription: mock-description\n';
       expect.assertions(1);
       expect(response).toEqual(expectedMessage);
+      process.stdin.isTTY = originalIsTTY;
     });
   });
 


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
`parseManifestFromStdin` behaves differently depending on the value of `process.stdin.isTTY`, but in tests where the value isn't explicitly set, tests could fail depending on the environment.

Specifically, tests were failing in environments where jest's `maxWorkers` was set to `1`.

<!-- Make sure tests and lint pass on CI. -->
This can be reproduced by running `npm test -- --runInBand` or `npm test -- --maxWorkers=1`.