### PR TITLE
fix(config): refine test configuration

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/__tests__/**/*.[jt]s'],
   transform: {
     '^.+\\.ts?$': [
       'ts-jest',
@@ -10,6 +11,9 @@ module.exports = {
       },
     ],
   },
-  modulePathIgnorePatterns: ['./build'],
-  coveragePathIgnorePatterns: ['src/.*/config/.*', 'src/.*/types/.*'],
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/src/.*/config/.*',
+    '<rootDir>/src/.*/types/.*',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "scripts": {
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "clean": "rimraf build/",
-    "coverage": "jest --verbose --coverage --testPathPattern=src/__tests__/",
+    "coverage": "jest --verbose --coverage",
     "fix": "gts fix",
     "fix:package": "fixpack",
     "if-check": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/if-check/index.ts",
@@ -90,7 +90,7 @@
     "prepare": "husky install",
     "prepublishOnly": "npm run build",
     "release": "release-it",
-    "test": "jest --verbose --testPathPattern=src/__tests__/"
+    "test": "jest --verbose"
   },
   "stability": "stable"
 }


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
The `modulePathIgnorePatterns` in `jest.config.js` was set to `./build`, which caused all modules to be ignored and tests not to be executed when the git working directory was under `build` (as it was in my environment). Therefore, I changed it to `<rootDir>/build/`.
(Since `modulePathIgnorePatterns` is a regex and is checked against the absolute path of the target, `./build` matches "paths that are under a directory with any name containing one or more characters (i.e., any directory other than the root directory) and start with `build`.)

Also made similar changes to `coveragePathIgnorePatterns` in `jest.config.js`.
(I don't think the git working directory will match `src/.*/config/.*` or `src/.*/types/.*` though...)

Additionally, both the `test` and `coverage` scripts in `package.json` had the `--testPathPattern=src/__tests__/` command line option specified. So, I added the pattern `<rootDir>/src/__tests__/**/*.[jt]s` (which is a Glob pattern, not a regex) to `testMatch` in `jest.config.js` and removed the command line option.
(For the same reason mentioned above, I included `<rootDir>` at the beginning.)
This enables running tests with a narrowed scope during test execution, such as `npm test -- --testPathPattern=if-run`.

<!-- Make sure tests and lint pass on CI. -->
