### PR TITLE
feat(src): add if-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,32 @@ if-run --help
 if-run -h
 ```
 
+### Using API server
+
+The Impact Framework also provides an API server. By default, it listens on localhost:3000, but this can be changed.
+
+```sh
+# Run the API server listening on the default localhost:3000.
+$ if-api
+
+# Run the API server listening on 0.0.0.0:8080.
+$ if-api --host 0.0.0.0 --port 8080
+```
+
+If the API server is running, you can send a manifest in the request body and receive the results of `if-run` as a response.
+
+```sh
+# Process manifest
+$ curl -H "Content-Type: application/yaml" --data-binary @manifest.yaml http://localhost:3000/v1/run
+```
+
+Note that in `if-api`, the following builtin plugins are disabled by default for security reasons.
+- Shell
+- CSVImport
+- CSVLookup
+
+Please refer to the documentation for detailed usage instructions, including how to enable these plugins.
+
 ## Documentation
 
 Please read our documentation at [if.greensoftware.foundation](https://if.greensoftware.foundation/)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,424 @@
+openapi: 3.0.3
+info:
+  title: Impact Framework Web API
+  description: |-
+    This API provides key feature of Impact Framework (IF) as a Web API.
+  license:
+    name: MIT license
+    url: https://github.com/Green-Software-Foundation/if/blob/main/LICENSE
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Impact Framework
+  url: https://if.greensoftware.foundation/
+components:
+  schemas:
+    aggregation-method-type:
+      type: string
+      enum:
+        - sum
+        - avg
+        - none
+        - copy
+    aggregation-method:
+      type: object
+      properties:
+        time:
+          $ref: '#/components/schemas/aggregation-method-type'
+        component:
+          $ref: '#/components/schemas/aggregation-method-type'
+      required:
+        - time
+        - component
+      additionalProperties: false
+    aggregation-type:
+      type: string
+      enum:
+        - horizontal
+        - time
+        - vertical
+        - component
+        - both
+    metadata:
+      type: object
+      additionalProperties:
+        type: object
+        properties:
+          unit:
+            type: string
+          description:
+            type: string
+          aggregation-method:
+            $ref: '#/components/schemas/aggregation-method'
+        required:
+          - unit
+          - description
+          - aggregation-method
+        additionalProperties: false
+      nullable: true
+    parameter-metadata:
+      type: object
+      properties:
+        inputs:
+          $ref: '#/components/schemas/metadata'
+        outputs:
+          $ref: '#/components/schemas/metadata'
+      additionalProperties: false
+    manifest:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        tags:
+          type: object
+          properties:
+            kind:
+              type: string
+              nullable: true
+            complexity:
+              type: string
+              nullable: true
+            category:
+              type: string
+              nullable: true
+          additionalProperties: false
+          nullable: true
+        explainer:
+          type: boolean
+        explain:
+          type: object
+        aggregation:
+          type: object
+          properties:
+            metrics:
+              type: array
+              items:
+                type: string
+            type:
+              $ref: '#/components/schemas/aggregation-type'
+            skip-components:
+              type: array
+              items:
+                type: string
+          required:
+            - metrics
+            - type
+          additionalProperties: false
+          nullable: true
+        initialize:
+          type: object
+          properties:
+            plugins:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  path:
+                    type: string
+                  method:
+                    type: string
+                  mapping:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  config:
+                    type: object
+                  parameter-metadata:
+                    $ref: '#/components/schemas/parameter-metadata'
+                required:
+                  - path
+                  - method
+                additionalProperties: false
+          required:
+            - plugins
+          additionalProperties: false
+        execution:
+          type: object
+          properties:
+            command:
+              type: string
+            environment:
+              type: object
+              properties:
+                if-version:
+                  type: string
+                os:
+                  type: string
+                os-version:
+                  type: string
+                node-version:
+                  type: string
+                date-time:
+                  type: string
+                dependencies:
+                  type: array
+                  items:
+                    type: string
+              required:
+                - if-version
+                - os
+                - os-version
+                - node-version
+                - date-time
+                - dependencies
+              additionalProperties: false
+            status:
+              type: string
+            error:
+              type: string
+          required:
+            - status
+          additionalProperties: false
+        tree:
+          type: object
+      required:
+        - name
+        - initialize
+        - tree
+      additionalProperties: false
+  examples:
+    request-yaml:
+      summary: 'sample request YAML'
+      value:
+        name: demo
+        initialize:
+          plugins:
+            double-a-value:
+              path: 'builtin'
+              method: Coefficient
+              config:
+                input-parameter: "cpu/utilization"
+                coefficient: 2
+                output-parameter: "cpu-utilization-doubled"
+        tree:
+          children:
+            child-0:
+              pipeline:
+                compute:
+                  - double-a-value
+              inputs:
+                - timestamp: 2023-07-06T00:00
+                  duration: 1
+                  cpu/utilization: 20
+                - timestamp: 2023-07-06T00:01
+                  duration: 1
+                  cpu/utilization: 80
+    request-json:
+      summary: 'sample request JSON'
+      value:
+        {
+          "name": "demo",
+          "initialize": {
+            "plugins": {
+              "double-a-value": {
+                "path": "builtin",
+                "method": "Coefficient",
+                "config": {
+                  "input-parameter": "cpu/utilization",
+                  "coefficient": 2,
+                  "output-parameter": "cpu-utilization-doubled"
+                }
+              }
+            }
+          },
+          "tree": {
+            "children": {
+              "child-0": {
+                "pipeline": {
+                  "compute": [
+                    "double-a-value"
+                  ]
+                },
+                "inputs": [
+                  {
+                    "timestamp": "2023-07-06T00:00",
+                    "duration": 1,
+                    "cpu/utilization": 20
+                  },
+                  {
+                    "timestamp": "2023-07-06T00:01",
+                    "duration": 1,
+                    "cpu/utilization": 80
+                  }
+                ]
+              }
+            }
+          }
+        }
+    response-yaml:
+      summary: 'sample response YAML'
+      value:
+        name: demo
+        initialize:
+          plugins:
+            double-a-value:
+              path: builtin
+              method: Coefficient
+              config:
+                input-parameter: cpu/utilization
+                coefficient: 2
+                output-parameter: cpu-utilization-doubled
+        execution:
+          command: /usr/bin/node /usr/local/bin/if-api
+          environment:
+            if-version: 1.0.1
+            os: Ubuntu
+            os-version: 24.04.2 LTS
+            node-version: 18.19.1
+            date-time: 2025-05-08T06:26:22.727Z (UTC)
+            dependencies: []
+          status: success
+        tree:
+          children:
+            child-0:
+              pipeline:
+                compute:
+                  - double-a-value
+              inputs:
+                - timestamp: 2023-07-06T00:00
+                  duration: 1
+                  cpu/utilization: 20
+                - timestamp: 2023-07-06T00:01
+                  duration: 1
+                  cpu/utilization: 80
+              outputs:
+                - timestamp: 2023-07-06T00:00
+                  duration: 1
+                  cpu/utilization: 20
+                  cpu-utilization-doubled: 40
+                - timestamp: 2023-07-06T00:01
+                  duration: 1
+                  cpu/utilization: 80
+                  cpu-utilization-doubled: 160
+    response-json:
+      summary: 'sample response JSON'
+      value:
+        {
+          "name": "demo",
+          "initialize": {
+            "plugins": {
+              "double-a-value": {
+                "path": "builtin",
+                "method": "Coefficient",
+                "config": {
+                  "input-parameter": "cpu/utilization",
+                  "coefficient": 2,
+                  "output-parameter": "cpu-utilization-doubled"
+                }
+              }
+            }
+          },
+          "execution": {
+            "command": "/usr/bin/node /usr/local/bin/if-api",
+            "environment": {
+              "if-version": "1.0.1",
+              "os": "Ubuntu",
+              "os-version": "24.04.2 LTS",
+              "node-version": "18.19.1",
+              "date-time": "2025-05-08T06:30:00.855Z (UTC)",
+              "dependencies": []
+            },
+            "status": "success"
+          },
+          "tree": {
+            "children": {
+              "child-0": {
+                "pipeline": {
+                  "compute": [
+                    "double-a-value"
+                  ]
+                },
+                "inputs": [
+                  {
+                    "timestamp": "2023-07-06T00:00",
+                    "duration": 1,
+                    "cpu/utilization": 20
+                  },
+                  {
+                    "timestamp": "2023-07-06T00:01",
+                    "duration": 1,
+                    "cpu/utilization": 80
+                  }
+                ],
+                "outputs": [
+                  {
+                    "timestamp": "2023-07-06T00:00",
+                    "duration": 1,
+                    "cpu/utilization": 20,
+                    "cpu-utilization-doubled": 40
+                  },
+                  {
+                    "timestamp": "2023-07-06T00:01",
+                    "duration": 1,
+                    "cpu/utilization": 80,
+                    "cpu-utilization-doubled": 160
+                  }
+                ]
+              }
+            }
+          }
+        }
+paths:
+  /v1/run:
+    post:
+      summary: Execute `if-run` with given manifest.
+      operationId: ifRun
+      parameters:
+        - in: query
+          name: observe
+          schema:
+            type: boolean
+          required: false
+          description: "executes only observe pipeline of the manifest"
+        - in: query
+          name: aggregate
+          schema:
+            type: boolean
+          required: false
+          description: "executes only regroup pipeline of the manifest"
+        - in: query
+          name: compute
+          schema:
+            type: boolean
+          required: false
+          description: "executes only compute pipeline of the manifest"
+      requestBody:
+        description: IF Manifest
+        content:
+          application/yaml:
+            schema:
+              $ref: '#/components/schemas/manifest'
+            examples:
+              sample:
+                $ref: '#/components/examples/request-yaml'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/manifest'
+            examples:
+              sample:
+                $ref: '#/components/examples/request-json'
+        required: true
+      responses:
+        '200':
+          description: Successful operation.
+          content:
+            application/yaml:
+              schema:
+                $ref: '#/components/schemas/manifest'
+              examples:
+                success:
+                  $ref: '#/components/examples/response-yaml'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/manifest'
+              examples:
+                success:
+                  $ref: '#/components/examples/response-json'
+        '400':
+          description: Validation Error
+        '415':
+          description: Invalid Content Type
+        '500':
+          description: Internal Server Error

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.2",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.4.6",
+        "express": "^5.1.0",
         "js-yaml": "^4.1.0",
         "luxon": "^3.4.4",
         "ts-command-line-args": "^2.5.1",
@@ -21,6 +22,7 @@
         "zod": "^3.22.4"
       },
       "bin": {
+        "if-api": "build/if-api/index.js",
         "if-check": "build/if-check/index.js",
         "if-csv": "build/if-csv/index.js",
         "if-diff": "build/if-diff/index.js",
@@ -34,6 +36,7 @@
         "@commitlint/cli": "^18.6.0",
         "@commitlint/config-conventional": "^18.6.0",
         "@jest/globals": "^29.6.1",
+        "@types/express": "^5.0.1",
         "@types/jest": "^29.5.7",
         "@types/js-yaml": "^4.0.5",
         "@types/luxon": "^3.4.2",
@@ -2164,6 +2167,52 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "dev": true,
@@ -2177,6 +2226,13 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -2224,6 +2280,13 @@
       "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "dev": true,
@@ -2242,10 +2305,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.5.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -2468,6 +2568,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/acorn": {
@@ -2909,6 +3043,55 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/boxen": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
@@ -3171,6 +3354,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -3209,6 +3401,35 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3711,6 +3932,27 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -3769,6 +4011,24 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
@@ -3975,7 +4235,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4306,6 +4565,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
@@ -4370,11 +4638,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.581",
@@ -4401,6 +4689,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -4489,13 +4786,10 @@
       "dev": true
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4504,7 +4798,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4530,10 +4823,10 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -4591,6 +4884,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -4937,6 +5236,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
@@ -4985,6 +5293,86 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend-object": {
@@ -5130,6 +5518,40 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/find-replace": {
@@ -5310,6 +5732,24 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -5345,7 +5785,6 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5407,16 +5846,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5431,6 +5875,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -5678,12 +6135,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5819,10 +6276,10 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -5861,7 +6318,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5890,6 +6346,22 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -6152,6 +6624,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -6531,6 +7012,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -8702,6 +9189,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "9.0.0",
       "dev": true,
@@ -8744,6 +9249,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -8900,6 +9417,15 @@
         "ncp": "bin/ncp"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -9029,10 +9555,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true,
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9064,9 +9593,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9444,6 +9984,15 @@
         "parse-path": "^7.0.0"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -9496,6 +10045,15 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/path-type": {
@@ -9663,6 +10221,19 @@
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
       "dev": true
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-agent": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
@@ -9734,6 +10305,21 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "dev": true,
@@ -9759,6 +10345,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rc": {
@@ -10594,6 +11216,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/run-applescript": {
       "version": "5.0.0",
       "dev": true,
@@ -10713,7 +11368,6 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -10743,6 +11397,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/set-function-length": {
@@ -10776,6 +11488,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -10814,15 +11532,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11024,6 +11796,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
@@ -11373,6 +12154,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -11497,6 +12287,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -11655,6 +12480,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "dev": true,
@@ -11774,6 +12608,15 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/walker": {
@@ -12034,7 +12877,6 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "if-env": "build/if-env/index.js",
     "if-check": "build/if-check/index.js",
     "if-csv": "build/if-csv/index.js",
-    "if-merge": "build/if-merge/index.js"
+    "if-merge": "build/if-merge/index.js",
+    "if-api": "build/if-api/index.js"
   },
   "bugs": {
     "url": "https://github.com/Green-Software-Foundation/if/issues/new?assignees=&labels=feedback&projects=&template=feedback.md&title=Feedback+-+"
@@ -22,6 +23,7 @@
     "axios": "^1.7.2",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.4.6",
+    "express": "^5.1.0",
     "js-yaml": "^4.1.0",
     "luxon": "^3.4.4",
     "ts-command-line-args": "^2.5.1",
@@ -35,6 +37,7 @@
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
     "@jest/globals": "^29.6.1",
+    "@types/express": "^5.0.1",
     "@types/jest": "^29.5.7",
     "@types/js-yaml": "^4.0.5",
     "@types/luxon": "^3.4.2",
@@ -79,6 +82,7 @@
     "coverage": "jest --verbose --coverage",
     "fix": "gts fix",
     "fix:package": "fixpack",
+    "if-api": "npx ts-node src/if-api/index.ts",
     "if-check": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/if-check/index.ts",
     "if-csv": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/if-csv/index.ts",
     "if-diff": "cross-env CURRENT_DIR=$(node -p \"process.env.INIT_CWD\") npx ts-node src/if-diff/index.ts",

--- a/src/__tests__/if-api/util/args.test.ts
+++ b/src/__tests__/if-api/util/args.test.ts
@@ -1,0 +1,157 @@
+import type {IfApiOptions} from '../../../if-api/types/process-args';
+import {STRINGS} from '../../../if-api/config';
+
+const {INVALID_PORT_NUMBER} = STRINGS;
+
+describe('if-api/util/args: ', () => {
+  describe('parseIfApiProcessArgs(): ', () => {
+    const argv = process.argv;
+
+    afterEach(() => {
+      process.argv = argv;
+      delete process.env.HOST;
+      delete process.env.PORT;
+    });
+
+    it('Default values', () => {
+      process.argv = [...process.argv.slice(0, 2)];
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        const response = parseIfApiProcessArgs();
+        const expectedResult: IfApiOptions = {
+          debug: false,
+          disableExternalPluginWarning: false,
+          disabledPlugins: undefined,
+          port: 3000,
+          host: 'localhost',
+        };
+
+        expect(response).toEqual(expectedResult);
+        expect.assertions(1);
+      });
+    });
+
+    it('Environment variable HOST', () => {
+      process.argv = [...process.argv.slice(0, 2)];
+      process.env.HOST = '0.0.0.0';
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        const response = parseIfApiProcessArgs();
+        const expectedResult: IfApiOptions = {
+          debug: false,
+          disableExternalPluginWarning: false,
+          disabledPlugins: undefined,
+          port: 3000,
+          host: '0.0.0.0',
+        };
+
+        expect(response).toEqual(expectedResult);
+        expect.assertions(1);
+      });
+    });
+
+    it('Environment variable HOST and command line option host', () => {
+      process.argv = [...process.argv.slice(0, 2), '--host', 'myhost'];
+      process.env.HOST = '0.0.0.0';
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        const response = parseIfApiProcessArgs();
+        const expectedResult: IfApiOptions = {
+          debug: false,
+          disableExternalPluginWarning: false,
+          disabledPlugins: undefined,
+          port: 3000,
+          host: 'myhost',
+        };
+
+        expect(response).toEqual(expectedResult);
+        expect.assertions(1);
+        expect.assertions(1);
+      });
+    });
+
+    it('Environment variable PORT', () => {
+      process.argv = [...process.argv.slice(0, 2)];
+      process.env.PORT = '8888';
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        const response = parseIfApiProcessArgs();
+        const expectedResult: IfApiOptions = {
+          debug: false,
+          disableExternalPluginWarning: false,
+          disabledPlugins: undefined,
+          port: 8888,
+          host: 'localhost',
+        };
+
+        expect(response).toEqual(expectedResult);
+        expect.assertions(1);
+      });
+    });
+
+    it('Environment variable PORT and command line option port', () => {
+      process.argv = [...process.argv.slice(0, 2), '--port', '3333'];
+      process.env.PORT = '8888';
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        const response = parseIfApiProcessArgs();
+        const expectedResult: IfApiOptions = {
+          debug: false,
+          disableExternalPluginWarning: false,
+          disabledPlugins: undefined,
+          port: 3333,
+          host: 'localhost',
+        };
+
+        expect(response).toEqual(expectedResult);
+        expect.assertions(1);
+      });
+    });
+
+    it('String specified for port', () => {
+      process.argv = [...process.argv.slice(0, 2), '--port', 'abc'];
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        expect(() => parseIfApiProcessArgs()).toThrow(
+          INVALID_PORT_NUMBER('abc')
+        );
+        expect.assertions(1);
+      });
+    });
+
+    it('Negative number for port', () => {
+      process.argv = [...process.argv.slice(0, 2), '--port', '-1'];
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        expect(() => parseIfApiProcessArgs()).toThrow(
+          INVALID_PORT_NUMBER('-1')
+        );
+        expect.assertions(1);
+      });
+    });
+
+    it('65536 for port', () => {
+      process.argv = [...process.argv.slice(0, 2), '--port', '65536'];
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        expect(() => parseIfApiProcessArgs()).toThrow(
+          INVALID_PORT_NUMBER('65536')
+        );
+        expect.assertions(1);
+      });
+    });
+
+    it('Non-existent option', () => {
+      process.argv = [...process.argv.slice(0, 2), '-z'];
+      jest.spyOn(process, 'exit').mockImplementation((code?: number) => {
+        expect(code).toEqual(1);
+        throw new Error(`process.exit(${code}) called`);
+      });
+      jest.isolateModules(() => {
+        const {parseIfApiProcessArgs} = require('../../../if-api/util/args');
+        expect(() => parseIfApiProcessArgs()).toThrow('process.exit(1) called');
+        expect.assertions(2);
+      });
+    });
+  });
+});

--- a/src/common/types/manifest.ts
+++ b/src/common/types/manifest.ts
@@ -5,6 +5,8 @@ import {manifestSchema} from '../util/validations';
 
 export type Manifest = z.infer<typeof manifestSchema>;
 
+export type Execution = NonNullable<Manifest['execution']>;
+
 export type GlobalPlugins = Manifest['initialize']['plugins'];
 
 export type PluginOptions = GlobalPlugins[string];

--- a/src/common/util/debug-logger.ts
+++ b/src/common/util/debug-logger.ts
@@ -1,3 +1,5 @@
+import {getStorage} from '../../common/util/storage';
+
 import {STRINGS} from '../../if-run/config';
 
 const logMessagesKeys: (keyof typeof STRINGS)[] = [
@@ -48,28 +50,10 @@ const overrideConsoleMethods = (debugMode: boolean) => {
 };
 
 /**
- * Creates an encapsulated object to retrieve the plugin name.
- */
-const pluginNameManager = (() => {
-  let pluginName: string | undefined = '';
-
-  const manager = {
-    get currentPluginName() {
-      return pluginName;
-    },
-    set currentPluginName(value: string | undefined) {
-      pluginName = value;
-    },
-  };
-
-  return manager;
-})();
-
-/**
  * Sets the name of the currently executing plugin.
  */
 const setExecutingPluginName = (pluginName?: string) => {
-  pluginNameManager.currentPluginName = pluginName;
+  getStorage().currentPluginName = pluginName;
 };
 
 /**
@@ -110,7 +94,7 @@ const debugLog = (level: LogLevel, args: any[], debugMode: boolean) => {
   }
 
   const date = new Date().toISOString();
-  const plugin = pluginNameManager.currentPluginName;
+  const plugin = getStorage().currentPluginName;
   const isExeption =
     typeof args[0] === 'string' && args[0].includes('**Computing');
   const message = `${level}: ${date}: ${plugin ? plugin + ': ' : ''}${args.join(

--- a/src/common/util/storage.ts
+++ b/src/common/util/storage.ts
@@ -1,0 +1,24 @@
+import {AsyncLocalStorage} from 'async_hooks';
+
+/**
+ * Create global storage
+ */
+const globalStorage: any = {};
+
+/**
+ * Create async local storage
+ */
+const asyncLocalStorage = new AsyncLocalStorage();
+
+/**
+ * Get the storage for the current context
+ */
+export const getStorage = () => asyncLocalStorage.getStore() || globalStorage;
+
+/**
+ * Set up the context and execute the process
+ * @param callback The process to be executed after the context is set up
+ */
+
+export const executeWithContext = (callback: () => void): void =>
+  asyncLocalStorage.run({}, callback);

--- a/src/if-api/config/config.ts
+++ b/src/if-api/config/config.ts
@@ -1,0 +1,60 @@
+import type {ArgumentConfig, ParseOptions} from 'ts-command-line-args';
+
+import {STRINGS} from '../../common/config';
+
+import type {IfApiArgs} from '../types/process-args';
+
+const {DISCLAIMER_MESSAGE} = STRINGS;
+
+/**
+ * Configuration for if-api.
+ */
+export const CONFIG = {
+  ARGS: {
+    debug: {
+      type: Boolean,
+      alias: 'd',
+      description: 'Print debug logs to the console',
+      defaultValue: false,
+    },
+    disableExternalPluginWarning: {
+      type: Boolean,
+      alias: 'w',
+      description: 'Disable external plugin warning',
+      defaultValue: false,
+    },
+    disabledPlugins: {
+      type: String,
+      alias: 'f',
+      description: 'Filename that contains plugin names to be disabled',
+      optional: true,
+    },
+    port: {
+      type: String,
+      alias: 'p',
+      description: 'Port to listen on',
+      defaultValue: process.env.PORT ?? '3000',
+    },
+    host: {
+      type: String,
+      alias: 'b',
+      description: 'Host to listen on',
+      defaultValue: process.env.HOST ?? 'localhost',
+    },
+    help: {
+      type: Boolean,
+      alias: 'h',
+      description: 'Show help',
+      optional: true,
+    },
+  } as ArgumentConfig<IfApiArgs>,
+  HELP: {
+    helpArg: 'help',
+    headerContentSections: [
+      {header: 'Impact Framework', content: 'Helpful keywords:'},
+    ],
+    footerContentSections: [
+      {header: 'Green Software Foundation', content: DISCLAIMER_MESSAGE},
+    ],
+  } as ParseOptions<IfApiArgs>,
+} as const;

--- a/src/if-api/config/index.ts
+++ b/src/if-api/config/index.ts
@@ -1,0 +1,2 @@
+export {CONFIG} from './config';
+export {STRINGS} from './strings';

--- a/src/if-api/config/strings.ts
+++ b/src/if-api/config/strings.ts
@@ -1,0 +1,19 @@
+/**
+ * Strings for if-api.
+ */
+export const STRINGS = {
+  SERVER_STARTED: (addr: string) => `Server started on ${addr}`,
+  SERVER_START_FAILED: (err: Error) => `Failed to start server: ${err}`,
+  PROCESSING_REQUEST: 'Processing request',
+  INTERNAL_SERVER_ERROR: 'Internal Server Error',
+  INVALID_JSON: 'Invalid JSON format',
+  INVALID_YAML: 'Invalid YAML format',
+  MISSING_MANIFEST: 'Missing manifest in request body',
+  UNSUPPORTED_CONTENT_TYPE:
+    'Unsupported content type. Supported types are: application/json, application/yaml',
+  DISCLAIMER_MESSAGE: 'Impact Framework API - Green Software Foundation',
+  INVALID_DISABLED_PLUGINS: (line: string) =>
+    `Invalid DisabledPlugins settings:${line}`,
+  INVALID_PORT_NUMBER: (port: string) =>
+    `Invalid port number \`${port}\`. The port number should be a number between 0 and 65535.`,
+} as const;

--- a/src/if-api/index.ts
+++ b/src/if-api/index.ts
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+import {open} from 'fs/promises';
+import type {AddressInfo} from 'net';
+
+import express from 'express';
+import type {NextFunction, Request, Response} from 'express';
+import {dump, load} from 'js-yaml';
+import {ERRORS} from '@grnsft/if-core/utils';
+
+import type {Manifest} from '../common/types/manifest';
+import {debugLogger} from '../common/util/debug-logger';
+import {logger} from '../common/util/logger';
+import {executeWithContext} from '../common/util/storage';
+import {validateManifest} from '../common/util/validations';
+
+import {aggregate} from '../if-run/lib/aggregate';
+import {getExecution} from '../if-run/lib/environment';
+import {
+  initialize,
+  setExternalPluginWarning,
+  setDisabledPlugins,
+} from '../if-run/lib/initialize';
+import {compute} from '../if-run/lib/compute';
+import {explain} from '../if-run/lib/explain';
+
+import {STRINGS} from './config';
+import {parseIfApiProcessArgs} from './util/args';
+
+const {
+  DISCLAIMER_MESSAGE,
+  INTERNAL_SERVER_ERROR,
+  INVALID_DISABLED_PLUGINS,
+  INVALID_JSON,
+  INVALID_YAML,
+  MISSING_MANIFEST,
+  PROCESSING_REQUEST,
+  SERVER_STARTED,
+  SERVER_START_FAILED,
+  UNSUPPORTED_CONTENT_TYPE,
+} = STRINGS;
+
+const CT_YAML = 'application/yaml';
+const CT_JSON = 'application/json';
+const CT_VALID = [CT_YAML, CT_JSON];
+
+const ERROR_LIST: readonly ErrorConstructor[] = Object.values(ERRORS);
+
+/**
+ * Determine response type.
+ */
+const determineResponseType = (req: express.Request) => {
+  const acceptHeader = req.get('Accept');
+  if (acceptHeader && acceptHeader !== '*/*') {
+    // Determine based on request Accept header
+    const responseType = req.accepts(CT_VALID);
+    if (responseType) {
+      return responseType;
+    }
+  }
+
+  // Determine based on request Content-Type
+  return req.get('Content-Type');
+};
+
+/**
+ * Send the response in the appropriate format.
+ */
+const sendResponse = (
+  req: Request,
+  res: Response,
+  manifest: Manifest,
+  status: number
+) => {
+  const responseType = determineResponseType(req);
+  if (responseType === CT_YAML) {
+    const yamlData = dump(manifest, {noRefs: true});
+    res.set('Content-Type', responseType);
+    res.status(status).send(yamlData);
+  } else {
+    res.set('Content-Type', responseType);
+    res.status(status).json(manifest);
+  }
+};
+
+/**
+ * Parse disabled plugins file
+ * @param filename Filename that contains plugin names to be disabled
+ * @returns Set of disabledPlugins
+ */
+const parseDisabledPlugins = async (filename: string | undefined) => {
+  // If no filename is specified, disable builtin:Shell, builtin:CSVImport, builtin:CSVLookup by default.
+  if (!filename) {
+    return new Set<string>([
+      'builtin:Shell',
+      'builtin:CSVImport',
+      'builtin:CSVLookup',
+    ]);
+  }
+
+  const disabledPlugins = new Set<string>();
+  const file = await open(filename);
+  try {
+    for await (const line of file.readLines()) {
+      const words = line.split(/ *: */);
+      switch (words.length) {
+        case 1:
+          disabledPlugins.add(`builtin:${words[0]}`);
+          break;
+        case 2:
+          disabledPlugins.add(`${words[0]}:${words[1]}`);
+          break;
+        default:
+          throw new Error(INVALID_DISABLED_PLUGINS(line));
+      }
+    }
+  } finally {
+    await file.close();
+  }
+  return disabledPlugins;
+};
+
+const formatAddr = (addr: string | AddressInfo | null): string => {
+  if (typeof addr === 'string') {
+    return addr;
+  } else if (addr === null) {
+    return 'unknown';
+  } else if (addr.family === 'IPv6') {
+    return `[${addr.address}]:${addr.port}`;
+  } else {
+    return `${addr.address}:${addr.port}`;
+  }
+};
+
+/**
+ * Start the API server.
+ */
+const startServer = async () => {
+  const options = parseIfApiProcessArgs();
+
+  debugLogger.overrideConsoleMethods(options.debug);
+
+  logger.info(DISCLAIMER_MESSAGE);
+
+  setExternalPluginWarning(!options.disableExternalPluginWarning);
+
+  const disabledPlugins = await parseDisabledPlugins(options.disabledPlugins);
+  setDisabledPlugins(disabledPlugins);
+
+  // Get execution information (command, environment).
+  const execution = await getExecution();
+
+  const app = express();
+
+  // Middleware for JSON requests
+  app.use(express.json({type: CT_JSON}));
+
+  // Custom middleware for YAML requests
+  app.use(
+    express.text({type: CT_YAML}),
+    (req: Request, res: Response, next: NextFunction): void => {
+      if (req.is(CT_YAML)) {
+        try {
+          req.body = load(req.body);
+        } catch (err: any) {
+          res.status(400).json({
+            error: INVALID_YAML,
+            detail: err.message,
+          });
+          return;
+        }
+      }
+      next();
+    }
+  );
+
+  // Add request context storage
+  app.use((_req: Request, _res: Response, next: NextFunction): void =>
+    executeWithContext(next)
+  );
+
+  // Health check endpoint
+  app.get('/health', (_req: Request, res: Response): void => {
+    res.status(200).send('OK');
+  });
+
+  // Process manifest endpoint
+  app.post('/v1/run', async (req: Request, res: Response): Promise<void> => {
+    logger.info(PROCESSING_REQUEST);
+
+    // Check if request body exists
+    if (!req.body) {
+      res.status(400).json({error: MISSING_MANIFEST});
+      return;
+    }
+
+    // Check request Content-Type
+    if (!req.is(CT_VALID)) {
+      res.status(415).json({error: UNSUPPORTED_CONTENT_TYPE});
+      return;
+    }
+
+    // Create manifest with execution information
+    const envManifest: Manifest = {
+      ...req.body,
+      execution: {
+        command: execution.command,
+        environment: {
+          ...execution.environment,
+          'date-time': `${new Date().toISOString()} (UTC)`,
+        },
+        status: execution.status,
+      },
+    };
+
+    try {
+      const {tree, ...context} = validateManifest(envManifest);
+
+      const pluginStorage = await initialize(context);
+
+      const computedTree = await compute(tree, {
+        context,
+        pluginStorage,
+        observe: req.query.observe === 'true',
+        regroup: req.query.regroup === 'true',
+        compute: req.query.compute === 'true',
+        append: false,
+      });
+
+      const aggregatedTree = aggregate(computedTree, context.aggregation);
+
+      envManifest.explainer && (context.explain = explain());
+
+      // Prepare response data
+      const responseData = {tree: aggregatedTree, ...context};
+
+      // Return response in the determined format
+      sendResponse(req, res, responseData, 200);
+    } catch (err) {
+      // If it's one of the errors in ERRORS, terminate with status code 400
+      if (ERROR_LIST.some(val => err instanceof val)) {
+        /** Execution block exists because manifest is already processed. Set's status to `fail`. */
+        envManifest.execution!.status = 'fail';
+        envManifest.execution!.error = (err as Error).toString();
+
+        // Return response in the determined format
+        sendResponse(req, res, envManifest, 400);
+        return;
+      }
+
+      // Set Content-Type to application/json
+      res.set('Content-Type', CT_JSON);
+      // For all other cases, terminate with status code 500
+      if (err instanceof Error) {
+        res.status(500).json({
+          error: INTERNAL_SERVER_ERROR,
+          detail: err.message,
+        });
+        return;
+      }
+      res.status(500).json({error: INTERNAL_SERVER_ERROR});
+    }
+  });
+
+  // Set up custom error handler
+  app.use(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (err: any, _req: Request, res: Response, _next: NextFunction): void => {
+      // Set Content-Type to application/json
+      res.set('Content-Type', CT_JSON);
+
+      // If SyntaxError (JSON parse error), terminate with status code 400
+      if (err.status === 400 && err instanceof SyntaxError && 'body' in err) {
+        res.status(400).json({
+          error: INVALID_JSON,
+          detail: err.message,
+        });
+      } else if (err instanceof Error) {
+        if ('status' in err) {
+          res.status(err.status as number).json({
+            error: err.message,
+          });
+        } else {
+          res.status(500).json({
+            error: INTERNAL_SERVER_ERROR,
+            detail: err.message,
+          });
+        }
+      } else {
+        res.status(500).json({
+          error: INTERNAL_SERVER_ERROR,
+        });
+      }
+    }
+  );
+
+  // Start the server
+  const {port, host} = options;
+  const server = app.listen(port, host, (err?: Error) => {
+    if (err) {
+      logger.error(SERVER_START_FAILED(err));
+      // eslint-disable-next-line no-process-exit
+      process.exit(2);
+    }
+    logger.info(SERVER_STARTED(formatAddr(server.address())));
+  });
+
+  // Handle Signal
+  const handler = (err: NodeJS.Signals) => {
+    logger.debug(`${err} signal received: closing HTTP server`);
+    server.close(() => {
+      logger.debug('HTTP server closed');
+    });
+  };
+  process.once('SIGTERM', handler);
+  process.once('SIGINT', handler);
+};
+
+// Start the server
+startServer().catch(err => {
+  logger.error(SERVER_START_FAILED(err));
+  // eslint-disable-next-line no-process-exit
+  process.exit(2);
+});

--- a/src/if-api/types/process-args.ts
+++ b/src/if-api/types/process-args.ts
@@ -1,0 +1,19 @@
+/**
+ * Interface for if-api process arguments.
+ */
+export interface IfApiArgs {
+  debug: boolean;
+  disableExternalPluginWarning: boolean;
+  disabledPlugins?: string;
+  port: string;
+  host: string;
+  help?: boolean;
+}
+
+export interface IfApiOptions {
+  debug: boolean;
+  disableExternalPluginWarning: boolean;
+  disabledPlugins: string | undefined;
+  port: number;
+  host: string;
+}

--- a/src/if-api/util/args.ts
+++ b/src/if-api/util/args.ts
@@ -1,0 +1,42 @@
+import {parse} from 'ts-command-line-args';
+
+import {CONFIG, STRINGS} from '../config';
+import type {IfApiArgs, IfApiOptions} from '../types/process-args';
+
+const {ARGS, HELP} = CONFIG;
+const {INVALID_PORT_NUMBER} = STRINGS;
+
+/**
+ * Validates `if-api` process arguments.
+ */
+const validateAndParseProcessArgs = (): IfApiArgs => {
+  try {
+    return parse<IfApiArgs>(ARGS, HELP);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(error.message);
+      console.log('Here are the supported flags for the `if-api` command:');
+      parse<IfApiArgs>(ARGS, {...HELP, argv: ['--help'], processExitCode: 1});
+    }
+    throw error;
+  }
+};
+
+/**
+ * Parse command line arguments for `if-api`.
+ */
+export const parseIfApiProcessArgs = (): IfApiOptions => {
+  const options = validateAndParseProcessArgs();
+  const port = parseInt(options.port, 10);
+  if (Number.isNaN(port) || port < 0 || port > 65535) {
+    throw new Error(INVALID_PORT_NUMBER(options.port));
+  }
+
+  return {
+    debug: options.debug,
+    disableExternalPluginWarning: options.disableExternalPluginWarning,
+    disabledPlugins: options.disabledPlugins,
+    port,
+    host: options.host,
+  };
+};

--- a/src/if-run/lib/aggregate.ts
+++ b/src/if-run/lib/aggregate.ts
@@ -3,6 +3,7 @@ import {PluginParams} from '@grnsft/if-core/types';
 
 import {debugLogger} from '../../common/util/debug-logger';
 import {logger} from '../../common/util/logger';
+import {getStorage} from '../../common/util/storage';
 import {
   AggregationParams,
   AggregationParamsSure,
@@ -112,32 +113,14 @@ export const storeAggregationMetrics = (
   aggregationMetrics?: AggregationMetricsWithMethod
 ) => {
   if (aggregationMetrics) {
-    metricManager.metrics = {
-      ...metricManager.metrics,
+    getStorage().metrics = {
+      ...getStorage().metrics,
       ...aggregationMetrics,
     };
   }
 
-  return metricManager.metrics;
+  return getStorage().metrics;
 };
-
-/**
- * Creates an encapsulated object to retrieve the metrics.
- */
-const metricManager = (() => {
-  let metric: AggregationMetricsWithMethod;
-
-  const manager = {
-    get metrics() {
-      return metric;
-    },
-    set metrics(value: AggregationMetricsWithMethod) {
-      metric = value;
-    },
-  };
-
-  return manager;
-})();
 
 /**
  * Returns aggregation method for given `metric`.

--- a/src/if-run/lib/environment.ts
+++ b/src/if-run/lib/environment.ts
@@ -1,6 +1,6 @@
 import {osInfo} from '../util/os-checker';
 import {execPromise} from '../../common/util/helpers';
-import {Manifest} from '../../common/types/manifest';
+import type {Execution, Manifest} from '../../common/types/manifest';
 
 import {STRINGS} from '../config/strings';
 import {NpmListResponse, PackageDependency} from '../types/environment';
@@ -61,11 +61,9 @@ const listDependencies = async () => {
 };
 
 /**
- * Injects execution information (command, environment) to existing manifest.
+ * Get execution information (command, environment).
  */
-export const injectEnvironment = async (
-  manifest: Manifest
-): Promise<Manifest> => {
+export const getExecution = async (): Promise<Execution> => {
   console.debug(CAPTURING_RUNTIME_ENVIRONMENT_DATA);
 
   const dependencies = await listDependencies();
@@ -73,18 +71,25 @@ export const injectEnvironment = async (
   const dateTime = `${getProcessStartingTimestamp()} (UTC)`;
 
   return {
-    ...manifest,
-    execution: {
-      status: 'success',
-      command: process.argv.join(' '),
-      environment: {
-        'if-version': packageJson.version,
-        os: info.os,
-        'os-version': info['os-version'],
-        'node-version': process.versions.node,
-        'date-time': dateTime,
-        dependencies,
-      },
+    status: 'success',
+    command: process.argv.join(' '),
+    environment: {
+      'if-version': packageJson.version,
+      os: info.os,
+      'os-version': info['os-version'],
+      'node-version': process.versions.node,
+      'date-time': dateTime,
+      dependencies,
     },
   };
 };
+
+/**
+ * Injects execution information (command, environment) to existing manifest.
+ */
+export const injectEnvironment = async (
+  manifest: Manifest
+): Promise<Manifest> => ({
+  ...manifest,
+  execution: await getExecution(),
+});


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
Based on Discussion #1129, I've first implemented the Web API as a command called `if-api`.
The main changes and points to note from @YaSuenag's proposal are as follows:
1. The `outputonly` option has not been implemented. (As I commented, because it's not clear which `outputs` to output)
2. The `observe`, `regroup`, and `compute` options are set up to be accepted as query parameters.
3. Additional input files are not supported.
4. The content type is set to the standard `application/yaml` instead of `application/vnd.if-manifest+yaml`.
5. It is also set up to accept `application/json`.
6. If there is an error in the manifest, it returns 400 instead of 200.
7. By default, three builtin plugins are disabled: `Shell`, `CSVImport`, and `CSVLookup`.

I've added a brief startup guide to `README.md`, but I'll submit the command reference in the following pull request to if-docs (currently a draft): https://github.com/Green-Software-Foundation/if-docs/pull/130

I look forward to your comments.
<!-- Make sure tests and lint pass on CI. -->
