### PR TITLE
chore(manifests): restore sample manifests

### DIFF
--- a/manifests/examples/bugs/aggregation-error-wrong-metric.yml
+++ b/manifests/examples/bugs/aggregation-error-wrong-metric.yml
@@ -1,0 +1,173 @@
+name: aggregation-error-wrong-metric
+description: a negative test case that fails due to the aggregation feature being passed an incorrect metric
+tags:
+aggregation:
+  metrics:
+    - "dummy-param"
+  type: "both"
+initialize:
+  plugins:
+    "interpolate":
+      method: Interpolation
+      path: 'builtin'
+      config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+    "cpu-factor-to-wattage":
+      method: Multiply
+      path: builtin
+      config:
+        input-parameters: ["cpu-factor", "cpu/thermal-design-power"]
+        output-parameter: "cpu-wattage"
+    "wattage-times-duration":
+      method: Multiply
+      path: builtin
+      config:
+        input-parameters: ["cpu-wattage", "duration"]
+        output-parameter: "cpu-wattage-times-duration"
+    "wattage-to-energy-kwh":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: cpu-wattage-times-duration
+        denominator: 3600000
+        output: cpu-energy-raw
+    "calculate-vcpu-ratio":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: vcpus-total
+        denominator: vcpus-allocated
+        output: vcpu-ratio
+    "correct-cpu-energy-for-vcpu-ratio":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: cpu-energy-raw
+        denominator: vcpu-ratio
+        output: cpu-energy-kwh
+    "sci-embodied":
+      path: "builtin"
+      method: SciEmbodied
+    "operational-carbon":
+      method: Multiply
+      path: builtin
+      config:
+        input-parameters: ["cpu-energy-kwh", "grid/carbon-intensity"]
+        output-parameter: "carbon"
+    "sci":
+      path: "builtin"
+      method: Sci
+      config:
+        functional-unit: "requests"
+    "time-sync":
+      method: TimeSync
+      path: "builtin"
+      config:
+        start-time: "2023-12-12T00:00:00.000Z"
+        end-time: "2023-12-12T00:01:00.000Z"
+        interval: 5
+        allow-padding: true
+tree:
+  children:
+    child-1:
+      pipeline:
+        regroup:
+          - cloud/region
+          - cloud/instance-type
+        compute:
+          - interpolate
+          - cpu-factor-to-wattage
+          - wattage-times-duration
+          - wattage-to-energy-kwh
+          - calculate-vcpu-ratio
+          - correct-cpu-energy-for-vcpu-ratio
+          - sci-embodied
+          - operational-carbon
+          - time-sync
+          - sci
+      defaults:
+        cpu/thermal-design-power: 100
+        grid/carbon-intensity: 800
+        device/emissions-embodied: 1533.120 # gCO2eq
+        time-reserved: 3600 # 1hr in seconds
+        device/expected-lifespan: 94608000 # 3 years in seconds
+        vcpus-allocated: 1
+        vcpus-total: 8
+      inputs:
+        - timestamp: "2023-12-12T00:00:00.000Z"
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          duration: 1
+          cpu/utilization: 10
+          requests: 100
+        - timestamp: "2023-12-12T00:00:01.000Z"
+          duration: 5
+          cpu/utilization: 20
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100
+        - timestamp: "2023-12-12T00:00:06.000Z"
+          duration: 7
+          cpu/utilization: 15
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100
+        - timestamp: "2023-12-12T00:00:13.000Z"
+          duration: 30
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          cpu/utilization: 15
+          requests: 100
+    child-2:
+      pipeline:
+        regroup:
+          - cloud/region
+          - cloud/instance-type
+        compute:
+          - interpolate
+          - cpu-factor-to-wattage
+          - wattage-times-duration
+          - wattage-to-energy-kwh
+          - calculate-vcpu-ratio
+          - correct-cpu-energy-for-vcpu-ratio
+          - sci-embodied
+          - operational-carbon
+          - time-sync
+          - sci
+      defaults:
+        cpu/thermal-design-power: 100
+        grid/carbon-intensity: 800
+        device/emissions-embodied: 1533.120 # gCO2eq
+        time-reserved: 3600 # 1hr in seconds
+        device/expected-lifespan: 94608000 # 3 years in seconds
+        vcpus-allocated: 1
+        vcpus-total: 8
+      inputs:
+        - timestamp: "2023-12-12T00:00:00.000Z"
+          duration: 1
+          cpu/utilization: 30
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100
+        - timestamp: "2023-12-12T00:00:01.000Z"
+          duration: 5
+          cpu/utilization: 28
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100
+        - timestamp: "2023-12-12T00:00:06.000Z"
+          duration: 7
+          cpu/utilization: 40
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100
+        - timestamp: "2023-12-12T00:00:13.000Z"
+          duration: 30
+          cpu/utilization: 33
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          requests: 100

--- a/manifests/examples/bugs/input-error-missing-duration.yml
+++ b/manifests/examples/bugs/input-error-missing-duration.yml
@@ -1,0 +1,25 @@
+name: input-error-missing-duration
+description: a negative test case that fails due to the required `duration` field being omitted from input data
+tags:
+initialize:
+  plugins:
+    "interpolate":
+      method: Interpolation
+      path: builtin
+      config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+tree:
+  children:
+    child-0:
+      defaults:
+        cpu/thermal-design-power: 100
+      pipeline:
+        compute:
+          - interpolate
+      inputs:
+        - timestamp: 2023-07-06T00:00
+          cpu/utilization: 20

--- a/manifests/examples/bugs/mock-observations-failure-duration-is-zero.yml
+++ b/manifests/examples/bugs/mock-observations-failure-duration-is-zero.yml
@@ -1,0 +1,33 @@
+name: mock-observation-demo
+description: a manifest demonstrating how to use the mock observations feature
+tags:
+initialize:
+  plugins:
+    mock-observations:
+      method: MockObservations
+      path: "builtin"
+      config:
+        timestamp-from: 2023-07-06T00:00
+        timestamp-to: 2023-07-06T00:10
+        duration: 0
+        components:
+          - cloud/instance-type: A1
+          - cloud/instance-type: B1
+        generators:
+          common:
+            region: uk-west
+            common-key: common-val
+          randint:
+            cpu/utilization:
+              min: 1
+              max: 99
+            memory/utilization:
+              min: 1
+              max: 99
+tree:
+  children:
+    child:
+      pipeline:
+        observe:
+          - mock-observations
+      inputs:

--- a/manifests/examples/bugs/pipeline-error-naming-mismatch.yml
+++ b/manifests/examples/bugs/pipeline-error-naming-mismatch.yml
@@ -1,0 +1,32 @@
+name: pipeline-error-naming-mismatch
+description: a negative test case that fails due to the plugin name in the pipeline not matching the name given in initialize
+tags:
+initialize:
+  plugins:
+    "interpolate":
+      method: Interpolation
+      path: builtin
+      config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+tree:
+  children:
+    child-0:
+      defaults:
+        cpu/thermal-design-power: 100
+      pipeline:
+        compute:
+          - wrong-name
+      inputs:
+        - timestamp: 2023-07-06T00:00
+          duration: 1
+          cpu/utilization: 20
+        - timestamp: 2023-07-06T00:01
+          duration: 1
+          cpu/utilization: 80
+        - timestamp: 2023-07-06T00:02
+          duration: 1
+          cpu/utilization: 20

--- a/manifests/examples/bugs/pipeline-error-uninitialized-plugin.yml
+++ b/manifests/examples/bugs/pipeline-error-uninitialized-plugin.yml
@@ -1,0 +1,33 @@
+name: pipeline-uninitialized-plugin-error
+description: a negative test case that fails due to an uninitialized plugin being invoked in a pipeline
+tags:
+initialize:
+  plugins:
+    "interpolate":
+      method: Interpolation
+      path: builtin
+      config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+tree:
+  children:
+    child-0:
+      defaults:
+        cpu/thermal-design-power: 100
+      pipeline:
+        compute:
+          - interpolate
+          - multiply
+      inputs:
+        - timestamp: 2023-07-06T00:00
+          duration: 1
+          cpu/utilization: 20
+        - timestamp: 2023-07-06T00:01
+          duration: 1
+          cpu/utilization: 80
+        - timestamp: 2023-07-06T00:02
+          duration: 1
+          cpu/utilization: 20

--- a/manifests/examples/bugs/pipeline-ordering-error.yml
+++ b/manifests/examples/bugs/pipeline-ordering-error.yml
@@ -1,0 +1,91 @@
+name: pipeline-ordering-error
+description: a negative test case that fails because sci-o is invoked too early in the pipeline (before its inputs are generated)
+tags:
+initialize:
+  plugins:
+    "interpolate":
+      method: Interpolation
+      path: 'builtin'
+      config:
+        method: linear
+        x: [0, 10, 50, 100]
+        y: [0.12, 0.32, 0.75, 1.02]
+        input-parameter: 'cpu/utilization'
+        output-parameter: 'cpu-factor'
+    "cpu-factor-to-wattage":
+      method: Multiply
+      path: builtin
+      config:
+        input-parameters: ["cpu-factor", "cpu/thermal-design-power"]
+        output-parameter: "cpu-wattage"
+    "wattage-times-duration":
+      method: Multiply
+      path: builtin
+      config:
+        input-parameters: ["cpu-wattage", "duration"]
+        output-parameter: "cpu-wattage-times-duration"
+    "wattage-to-energy-kwh":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: cpu-wattage-times-duration
+        denominator: 3600000
+        output: cpu-energy-raw
+    "calculate-vcpu-ratio":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: vcpus-total
+        denominator: vcpus-allocated
+        output: vcpu-ratio
+    "correct-cpu-energy-for-vcpu-ratio":
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: cpu-energy-raw
+        denominator: vcpu-ratio
+        output: cpu-energy-kwh
+tree:
+  children:
+    child-1:
+      pipeline:
+        compute:
+          - interpolate
+          - correct-cpu-energy-for-vcpu-ratio
+          - calculate-vcpu-ratio
+          - cpu-factor-to-wattage
+          - wattage-times-duration
+          - wattage-to-energy-kwh
+      defaults:
+        cpu/thermal-design-power: 100
+        grid/carbon-intensity: 800
+        device/emissions-embodied: 1533.120 # gCO2eq
+        time-reserved: 3600 # 1hr in seconds
+        device/expected-lifespan: 94608000 # 3 years in seconds
+        vcpus-allocated: 1
+        vcpus-total: 8
+      inputs:
+        - timestamp: "2023-12-12T00:00:00.000Z"
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          duration: 1
+          cpu/utilization: 50
+          network/energy: 0.000001
+        - timestamp: "2023-12-12T00:00:01.000Z"
+          duration: 5
+          cpu/utilization: 20
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          network/energy: 0.000001
+        - timestamp: "2023-12-12T00:00:06.000Z"
+          duration: 7
+          cpu/utilization: 15
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          network/energy: 0.000001
+        - timestamp: "2023-12-12T00:00:13.000Z"
+          duration: 30
+          cloud/instance-type: A1
+          cloud/region: uk-west
+          cpu/utilization: 15
+          network/energy: 0.000001

--- a/manifests/examples/builtins/divide/success-denominator-equal-zero.yml
+++ b/manifests/examples/builtins/divide/success-denominator-equal-zero.yml
@@ -1,0 +1,36 @@
+name: divide
+description: denominator is invalid, denominator is
+tags:
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ["cpu-cores-utilized", "vcpus-allocated"]
+    divide:
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: vcpus-allocated
+        denominator: 0
+        output: cpu/number-cores
+tree:
+  children:
+    child:
+      pipeline:
+        compute:
+          - cloud-metadata
+          - divide
+      defaults:
+        cloud/vendor: aws
+        cloud/instance-type: m5n.large
+        cpu/name: Intel® Core™ i7-1185G7
+      inputs:
+        - timestamp: 2023-08-06T00:00
+          duration: 3600
+          cpu/utilization: 80

--- a/manifests/examples/builtins/sci-embodied/failure-invalid-default-emission-value.yml
+++ b/manifests/examples/builtins/sci-embodied/failure-invalid-default-emission-value.yml
@@ -1,0 +1,22 @@
+name: sci-embodied
+description: failure with `vCPUs` being string instead of number
+tags:
+initialize:
+  plugins:
+    "sci-embodied": # a model that calculates m from te, tir, el, rr and rtor
+      method: SciEmbodied
+      path: "builtin"
+tree:
+  children:
+    child:
+      pipeline:
+        compute:
+          - sci-embodied # duration & config -> embodied
+      defaults:
+        vCPUs: fail
+        time-reserved: 3600 # 1hr in seconds
+        resources-reserved: 1
+        resources-total: 8
+      inputs:
+        - timestamp: 2023-07-06T00:00
+          duration: 3600

--- a/manifests/examples/features/aggregate-failure-invalid-metrics.yml
+++ b/manifests/examples/features/aggregate-failure-invalid-metrics.yml
@@ -1,0 +1,50 @@
+name: Aggregation
+description: Fails with invalid metric.
+aggregation:
+  metrics:
+    - 'test'
+  type: 'both'
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+tree:
+  children:
+    application:
+      pipeline:
+        compute:
+          - cloud-metadata
+      children:
+        uk-west:
+          children:
+            server-1:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 89
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 59
+            server-2:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 24
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 27

--- a/manifests/examples/features/aggregate-failure-missing-metric-in-inputs.yml
+++ b/manifests/examples/features/aggregate-failure-missing-metric-in-inputs.yml
@@ -1,0 +1,50 @@
+name: Aggregation
+description: Fails with missing metric in inputs.
+aggregation:
+  metrics:
+    - 'cpu/utilization'
+  type: 'both'
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+tree:
+  children:
+    application:
+      pipeline:
+        compute:
+          - cloud-metadata
+      children:
+        uk-west:
+          children:
+            server-1:
+              inputs:
+                - timestamp: '2024-01-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 89
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 59
+            server-2:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                #  cpu/utilization: 110
+                - timestamp: '2024-02-26 00:15:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 27

--- a/manifests/examples/features/aggregate-horizontal.yml
+++ b/manifests/examples/features/aggregate-horizontal.yml
@@ -1,0 +1,58 @@
+name: Aggregation
+description: Apply `horizontal` aggregation
+aggregation:
+  metrics:
+    - 'cpu/utilization'
+  type: 'horizontal'
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+      parameter-metadata:
+        inputs:
+          cpu/utilization:
+            unit: percentage
+            description: refers to CPU utilization.
+            aggregation-method:
+              time: avg
+              component: avg
+tree:
+  children:
+    application:
+      pipeline:
+        compute:
+          - cloud-metadata
+      children:
+        uk-west:
+          children:
+            server-1:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 89
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 59
+            server-2:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 24
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 27

--- a/manifests/examples/features/aggregate-vertical.yml
+++ b/manifests/examples/features/aggregate-vertical.yml
@@ -1,0 +1,58 @@
+name: Aggregation
+description: Apply `vertical` aggregation
+aggregation:
+  metrics:
+    - 'cpu/utilization'
+  type: 'vertical'
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+      parameter-metadata:
+        inputs:
+          cpu/utilization:
+            unit: percentage
+            description: refers to CPU utilization.
+            aggregation-method:
+              time: avg
+              component: avg
+tree:
+  children:
+    application:
+      pipeline:
+        compute:
+          - cloud-metadata
+      children:
+        uk-west:
+          children:
+            server-1:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 89
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 59
+            server-2:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 24
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 27

--- a/manifests/examples/features/aggregate.yml
+++ b/manifests/examples/features/aggregate.yml
@@ -1,0 +1,58 @@
+name: Aggregation
+description: Apply both `horizontal` and `vertical` aggregations
+aggregation:
+  metrics:
+    - 'cpu/utilization'
+  type: 'both'
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+      parameter-metadata:
+        inputs:
+          cpu/utilization:
+            unit: percentage
+            description: refers to CPU utilization.
+            aggregation-method:
+              time: avg
+              component: avg
+tree:
+  children:
+    application:
+      pipeline:
+        compute:
+          - cloud-metadata
+      children:
+        uk-west:
+          children:
+            server-1:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 89
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 59
+            server-2:
+              inputs:
+                - timestamp: '2024-02-26 00:00:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 24
+                - timestamp: '2024-02-26 00:05:00'
+                  duration: 300
+                  cloud/instance-type: m5n.large
+                  cloud/vendor: aws
+                  cpu/utilization: 27

--- a/manifests/examples/pipelines/cloud-metadata-divide.yml
+++ b/manifests/examples/pipelines/cloud-metadata-divide.yml
@@ -1,0 +1,36 @@
+name: divide-demo
+description:
+tags:
+initialize:
+  plugins:
+    cloud-metadata:
+      path: builtin
+      method: CSVLookup
+      config:
+        filepath: >-
+          https://raw.githubusercontent.com/Green-Software-Foundation/if-data/main/cloud-metdata-aws-instances.csv
+        query:
+          instance-class: cloud/instance-type
+        output: ['cpu-cores-utilized', 'vcpus-allocated']
+    divide:
+      method: Divide
+      path: "builtin"
+      config:
+        numerator: vcpus-allocated
+        denominator: 2
+        output: cpu/number-cores
+tree:
+  children:
+    child:
+      pipeline:
+        compute:
+          - cloud-metadata
+          - divide
+      defaults:
+        cloud/vendor: aws
+        cloud/instance-type: m5n.large
+        cpu/name: Intel® Core™ i7-1185G7
+      inputs:
+        - timestamp: 2023-08-06T00:00
+          duration: 3600
+          cpu/utilization: 80


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
Restore the following files from past history where output files exist in `manifests/outputs` but corresponding input files don't exist in `manifests/examples`.
(In parentheses are the commit hash where they were deleted and the filename at that time)

- manifests/examples/bugs/aggregation-error-wrong-metric.yml
  (a5c9ad2a manifests/bugs/aggregation-error-wrong-metric.yml)
- manifests/examples/bugs/input-error-missing-duration.yml
  (a5c9ad2a manifests/bugs/input-error-missing-duration.yml)
- manifests/examples/bugs/mock-observations-failure-duration-is-zero.yml
  (a5c9ad2a manifests/bugs/mock-observations-failure-duration-is-zero.yml)
- manifests/examples/bugs/pipeline-error-naming-mismatch.yml
  (a5c9ad2a manifests/bugs/pipeline-error-naming-mismatch.yml)
- manifests/examples/bugs/pipeline-error-uninitialized-plugin.yml
  (a5c9ad2a manifests/bugs/pipeline-error-uninitialized-plugin.yml)
- manifests/examples/bugs/pipeline-ordering-error.yml
  (a5c9ad2a manifests/bugs/pipeline-ordering-error.yml)
- manifests/examples/features/aggregate-failure-invalid-metrics.yml
  (a5c9ad2a manifests/features/aggregate-failure-invalid-metrics.yml)
- manifests/examples/features/aggregate-failure-missing-metric-in-inputs.yml
  (a5c9ad2a manifests/features/aggregate-failure-missing-metric-in-inputs.yml)
- manifests/examples/features/aggregate-horizontal.yml
  (a5c9ad2a manifests/features/aggregate-horizontal.yml)
- manifests/examples/features/aggregate-vertical.yml
  (a5c9ad2a manifests/features/aggregate-vertical.yml)
- manifests/examples/features/aggregate.yml
  (a5c9ad2a manifests/features/aggregate.yml)
- manifests/examples/pipelines/cloud-metadata-divide.yml
  (a5c9ad2a manifests/integrations/cloud-metadata-divide.yml)
- manifests/examples/builtins/sci-embodied/failure-invalid-default-emission-value.yml
  (b2c4f222 manifests/examples/builtins/sci-embodied/failure-invalid-default-emission-value.yml)
- manifests/examples/builtins/divide/success-denominator-equal-zero.yml
  (1f609484 manifests/examples/builtins/divide/failure-denominator-equal-zero.yml)

<!-- Make sure tests and lint pass on CI. -->
I have confirmed that the results of running the added manifests with `if-run` match the corresponding outputs that originally existed in `manifests/outputs` using `if-diff`.
