### PR TITLE
Upgraded eco-ci to @v5

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -7,17 +7,19 @@ jobs:
       pull-requests: write # this allows to show carbon and energy data table in PRs
     steps:
       - name: Eco CI Energy Estimation - Initialize
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
-
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
         with:
           task: start-measurement
+          send-data: true
+          co2-calculation-method: "constant"
+          co2-grid-intensity-constant: 383
         continue-on-error: true
 
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: get-measurement
@@ -31,7 +33,7 @@ jobs:
           cache: 'npm'
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: get-measurement
@@ -43,7 +45,7 @@ jobs:
         run: npm install
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: get-measurement
@@ -55,7 +57,7 @@ jobs:
         run: npm run lint
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: get-measurement
@@ -67,7 +69,7 @@ jobs:
         run: npm run test --silent
 
       - name: Eco CI Energy Estimation - Get Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: get-measurement
@@ -75,11 +77,9 @@ jobs:
         continue-on-error: true
 
       - name: Eco CI Energy Estimation - End Measurement
-        uses: green-coding-solutions/eco-ci-energy-estimation@v4.0-rc3
+        uses: green-coding-solutions/eco-ci-energy-estimation@v5
 
         with:
           task: display-results
-          send-data: true
           pr-comment: true
         continue-on-error: true
-


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
This is an update to the Eco CI extension used to estimate the carbon cost of the CI/CD pipelines.

The initial PR was made here: https://github.com/Green-Software-Foundation/if/pull/736

This PR updates Eco CI to `v5`.
The new version allows to set a fixed carbon intensity when no dynamic API like ElectricityMaps is available.

Since you are using US based GitHub runners I set the carbon intensity to the avg from the US based on the data from the GreenWebFoundation (https://github.com/thegreenwebfoundation/co2.js/blob/main/data/output/average-intensities.json#L1262) 

