### PR TITLE
feat(src): add if-viz CLI tool for local manifest visualisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/__tests__/integration/manifest
 examples/outputs
 with-plugins/*
 !with-plugins/Dockerfile
+.scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Impact Framework (IF)** is a TypeScript framework by the Green Software Foundation for modelling, measuring, and monitoring the environmental impacts of software. It uses a plugin-based pipeline architecture that processes YAML manifest files describing component trees and computation pipelines.
+
+## Common Commands
+
+```bash
+# Build
+npm run build          # TypeScript compilation to /build
+
+# Test
+npm test                                          # Run all tests (Jest, verbose)
+npm test -- src/__tests__/if-run/lib/compute.test.ts  # Run a single test file
+npm run coverage                                  # Generate coverage report
+
+# Lint
+npm run lint           # GTS (Google TypeScript Style) linting
+npm run fix            # Auto-fix lint issues
+
+# CLI tools (after build)
+npx if-run -m <manifest.yaml>           # Run a manifest
+npx if-run -m <manifest.yaml> --debug   # Run with debug logging
+npx if-check -m <manifest.yaml>         # Validate a manifest
+npx if-diff -s <source.yaml> -t <target.yaml>  # Compare outputs
+npx if-csv -m <manifest.yaml>           # Export to CSV
+npx if-api                              # Start REST API server (port 3000)
+```
+
+## Architecture
+
+### Execution Flow (if-run)
+
+1. Parse CLI args → load manifest YAML → inject environment variables → validate with Zod
+2. **Initialize**: Load plugins from manifest's `initialize.plugins` and register in plugin storage
+3. **Compute**: Depth-first traversal of the component tree — for each leaf node: merge defaults → observe → regroup → compute
+4. **Aggregate**: Apply horizontal (time) and/or vertical (component) aggregation
+5. **Exhaust**: Write results to YAML/console
+
+Pipeline phases (observe, regroup, compute) can be run in isolation via `--observe`, `--regroup`, `--compute` flags.
+
+### Source Layout
+
+- `src/if-run/` — Main execution engine: pipeline orchestration, plugin loading, aggregation, output
+- `src/if-run/builtins/` — ~19 built-in plugins (multiply, sum, divide, sci, csv-lookup, time-sync, etc.)
+- `src/if-api/` — Express v5 REST API server with the same core execution as if-run
+- `src/if-check/`, `src/if-csv/`, `src/if-diff/`, `src/if-env/`, `src/if-merge/`, `src/if-metadata-check/` — Auxiliary CLI tools
+- `src/common/` — Shared utilities (logger, Zod validation, YAML I/O, filesystem helpers)
+- `src/__tests__/` — Test suites mirroring source structure
+- `src/__mocks__/` — Jest mocks
+
+### Plugin System
+
+Plugins implement the `PluginInterface` from `@grnsft/if-core/types` and are created via `PluginFactory` from `@grnsft/if-core/interfaces`:
+
+```typescript
+export const MyPlugin = PluginFactory({
+  configValidation: (config: ConfigParams) => { /* Zod validation */ },
+  inputValidation: (input: PluginParams, config: ConfigParams) => { /* Zod validation */ },
+  implementation: async (inputs: PluginParams[], config: ConfigParams) => { /* return transformed inputs */ },
+  allowArithmeticExpressions: [],
+});
+```
+
+Built-in plugins use `path: 'builtin'` in the manifest. External plugins use npm module paths or GitHub URLs. The plugin storage (`src/if-run/util/plugin-storage.ts`) is a simple name→instance registry.
+
+### Manifest Structure
+
+Manifests are YAML files with: `name`, `initialize.plugins` (plugin definitions with path, method, config, mapping), `tree` (component hierarchy with pipeline, defaults, inputs), and optional `aggregation` settings. Validated at runtime using Zod schemas in `src/common/util/validations.ts`.
+
+### Key Dependencies
+
+- `@grnsft/if-core` — Core types, interfaces (`PluginFactory`), error classes, aggregation constants
+- `zod` — Schema validation throughout
+- `js-yaml` — YAML parsing/generation
+- `luxon` — Date/time handling (used in time-sync, time-converter plugins)
+
+## Commit Conventions
+
+Conventional commits enforced via commitlint. Scope is **required**.
+
+- **Types**: feat, fix, docs, chore, style, refactor, ci, test, revert
+- **Scopes**: util, lib, types, src, package, config, mocks, .github, .husky, scripts, builtins, plugins, integration, doc, manifests, release, .commitlint
+
+Example: `feat(builtins): add new interpolation method`
+
+## Testing
+
+Tests are in `src/__tests__/` mirroring the source tree. Jest with ts-jest. Mocks live in `src/__mocks__/`. Coverage excludes config and types directories.
+
+## API Server Notes
+
+The API server (`if-api`) disables Shell, CSVImport, and CSVLookup plugins by default for security. Uses request-scoped context storage to prevent cross-request contamination.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express": "^5.1.0",
         "js-yaml": "^4.1.0",
         "luxon": "^3.4.4",
+        "open": "^11.0.0",
         "ts-command-line-args": "^2.5.1",
         "typescript-cubic-spline": "^1.0.1",
         "winston": "^3.11.0",
@@ -2306,6 +2307,330 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@pkgr/utils/node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/default-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+      "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^7.1.1",
+        "titleize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/execa": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/human-signals": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/run-applescript/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@pkgr/utils/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@pkgr/utils/node_modules/tslib": {
       "version": "2.6.2",
       "dev": true,
@@ -3139,7 +3464,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/big-integer": {
-      "version": "1.6.51",
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "dev": true,
       "license": "Unlicense",
       "engines": {
@@ -3197,6 +3524,8 @@
     },
     "node_modules/bplist-parser": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3285,14 +3614,15 @@
       "license": "MIT"
     },
     "node_modules/bundle-name": {
-      "version": "3.0.0",
-      "dev": true,
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "license": "MIT",
       "dependencies": {
-        "run-applescript": "^5.0.0"
+        "run-applescript": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4131,134 +4461,28 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "4.0.0",
-      "dev": true,
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "license": "MIT",
       "dependencies": {
-        "bundle-name": "^3.0.0",
-        "default-browser-id": "^3.0.0",
-        "execa": "^7.1.1",
-        "titleize": "^3.0.0"
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/default-browser-id": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bplist-parser": "^0.2.0",
-        "untildify": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/execa": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/default-browser/node_modules/human-signals": {
-      "version": "4.3.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.18.0"
-      }
-    },
-    "node_modules/default-browser/node_modules/is-stream": {
-      "version": "3.0.0",
-      "dev": true,
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/npm-run-path": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/onetime": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/path-key": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser/node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4266,7 +4490,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6074,6 +6297,8 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6121,9 +6346,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -6140,7 +6376,6 @@
     },
     "node_modules/is-inside-container/node_modules/is-docker": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -6251,14 +6486,18 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
       "license": "MIT",
       "dependencies": {
-        "is-docker": "^2.0.0"
+        "is-inside-container": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -8620,17 +8859,20 @@
       }
     },
     "node_modules/open": {
-      "version": "9.1.0",
-      "dev": true,
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^4.0.0",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^2.2.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9118,6 +9360,18 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -9557,22 +9811,6 @@
         "node": "^20.12.0 || >=22.0.0"
       }
     },
-    "node_modules/release-it/node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/release-it/node_modules/ci-info": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
@@ -9587,36 +9825,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/release-it/node_modules/default-browser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
-      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/release-it/node_modules/default-browser-id": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
-      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/inquirer": {
@@ -9644,22 +9852,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/release-it/node_modules/is-wsl": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/release-it/node_modules/mime-db": {
@@ -9707,19 +9899,6 @@
         "is-inside-container": "^1.0.0",
         "is-wsl": "^3.1.0"
       },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/release-it/node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -9974,14 +10153,12 @@
       }
     },
     "node_modules/run-applescript": {
-      "version": "5.0.0",
-      "dev": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "license": "MIT",
-      "dependencies": {
-        "execa": "^5.0.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10726,6 +10903,8 @@
     },
     "node_modules/titleize": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+      "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10984,6 +11163,8 @@
     },
     "node_modules/untildify": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11354,6 +11535,22 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "if-csv": "build/if-csv/index.js",
     "if-merge": "build/if-merge/index.js",
     "if-api": "build/if-api/index.js",
-    "if-metadata-check": "build/if-metadata-check/index.js"
+    "if-metadata-check": "build/if-metadata-check/index.js",
+    "if-viz": "build/if-viz/index.js"
   },
   "bugs": {
     "url": "https://github.com/Green-Software-Foundation/if/issues/new?assignees=&labels=feedback&projects=&template=feedback.md&title=Feedback+-+"
@@ -27,6 +28,7 @@
     "express": "^5.1.0",
     "js-yaml": "^4.1.0",
     "luxon": "^3.4.4",
+    "open": "^11.0.0",
     "ts-command-line-args": "^2.5.1",
     "typescript-cubic-spline": "^1.0.1",
     "winston": "^3.11.0",

--- a/src/if-viz/config/config.ts
+++ b/src/if-viz/config/config.ts
@@ -1,0 +1,44 @@
+import type {ArgumentConfig, ParseOptions} from 'ts-command-line-args';
+
+import {STRINGS} from '../../common/config';
+
+import type {IfVizArgs} from '../types/process-args';
+
+const {DISCLAIMER_MESSAGE} = STRINGS;
+
+export const CONFIG = {
+  VIZ_URL: 'https://viz.if.greensoftware.foundation',
+  ARGS: {
+    manifest: {
+      type: String,
+      alias: 'm',
+      description: '[path to the output manifest file]',
+    },
+    port: {
+      type: String,
+      alias: 'p',
+      description: '[port for the local file server]',
+      defaultValue: '8080',
+    },
+    'no-open': {
+      type: Boolean,
+      description: '[do not open the browser automatically]',
+      defaultValue: false,
+    },
+    help: {
+      type: Boolean,
+      alias: 'h',
+      description: '[prints out the above help instruction]',
+      optional: true,
+    },
+  } as ArgumentConfig<IfVizArgs>,
+  HELP: {
+    helpArg: 'help',
+    headerContentSections: [
+      {header: 'Impact Framework', content: 'IF-Viz Helpful keywords:'},
+    ],
+    footerContentSections: [
+      {header: 'Green Software Foundation', content: DISCLAIMER_MESSAGE},
+    ],
+  } as ParseOptions<IfVizArgs>,
+} as const;

--- a/src/if-viz/config/index.ts
+++ b/src/if-viz/config/index.ts
@@ -1,0 +1,2 @@
+export {CONFIG} from './config';
+export {STRINGS} from './strings';

--- a/src/if-viz/config/strings.ts
+++ b/src/if-viz/config/strings.ts
@@ -1,0 +1,9 @@
+export const STRINGS = {
+  SERVER_STARTED: (addr: string) => `Serving files on ${addr}`,
+  SERVER_START_FAILED: (err: Error) => `Failed to start server: ${err}`,
+  OPENING_BROWSER: (url: string) => `Opening browser: ${url}`,
+  MANIFEST_NOT_FOUND: (path: string) => `Manifest file not found: ${path}`,
+  INVALID_PORT_NUMBER: (port: string) =>
+    `Invalid port number \`${port}\`. The port number should be a number between 0 and 65535.`,
+  STOP_MESSAGE: 'Press Ctrl+C to stop the server.',
+} as const;

--- a/src/if-viz/index.ts
+++ b/src/if-viz/index.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/* eslint-disable no-process-exit */
+import * as path from 'path';
+import type {AddressInfo} from 'net';
+
+import express from 'express';
+
+import {logger} from '../common/util/logger';
+
+import {parseIfVizArgs} from './util/args';
+
+import {CONFIG, STRINGS} from './config';
+
+const {VIZ_URL} = CONFIG;
+const {SERVER_STARTED, SERVER_START_FAILED, OPENING_BROWSER, STOP_MESSAGE} =
+  STRINGS;
+
+const IfViz = async () => {
+  const {manifest, port, noOpen} = await parseIfVizArgs();
+
+  const directory = path.dirname(manifest);
+  const filename = path.basename(manifest);
+
+  const app = express();
+
+  // Enable CORS for all origins so the viz app can fetch the manifest.
+  app.use((_req, res, next) => {
+    res.set('Access-Control-Allow-Origin', '*');
+    res.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.set('Access-Control-Allow-Headers', 'Content-Type');
+    next();
+  });
+
+  // Serve the manifest's directory as static files.
+  app.use(express.static(directory));
+
+  const server = app.listen(port, () => {
+    const addr = server.address() as AddressInfo;
+    const serverUrl = `http://localhost:${addr.port}`;
+
+    logger.info(SERVER_STARTED(serverUrl));
+    logger.info(STOP_MESSAGE);
+
+    if (!noOpen) {
+      const fileUrl = `${serverUrl}/${filename}`;
+      const vizUrl = `${VIZ_URL}/?url=${encodeURIComponent(fileUrl)}`;
+      logger.info(OPENING_BROWSER(vizUrl));
+
+      import('open').then(({default: open}) => open(vizUrl));
+    }
+  });
+
+  server.on('error', (err: Error) => {
+    logger.error(SERVER_START_FAILED(err));
+    process.exit(2);
+  });
+
+  const handler = (signal: NodeJS.Signals) => {
+    logger.debug(`${signal} signal received: closing server`);
+    server.close(() => {
+      logger.debug('Server closed');
+    });
+  };
+  process.once('SIGTERM', handler);
+  process.once('SIGINT', handler);
+};
+
+IfViz().catch(err => {
+  if (err instanceof Error) {
+    logger.error(err);
+    process.exit(2);
+  }
+});

--- a/src/if-viz/types/process-args.ts
+++ b/src/if-viz/types/process-args.ts
@@ -1,0 +1,12 @@
+export interface IfVizArgs {
+  manifest: string;
+  port: string;
+  'no-open': boolean;
+  help?: boolean;
+}
+
+export interface IfVizOptions {
+  manifest: string;
+  port: number;
+  noOpen: boolean;
+}

--- a/src/if-viz/util/args.ts
+++ b/src/if-viz/util/args.ts
@@ -1,0 +1,52 @@
+import * as path from 'path';
+
+import {parse} from 'ts-command-line-args';
+
+import {isFileExists} from '../../common/util/fs';
+
+import {CONFIG, STRINGS} from '../config';
+
+import type {IfVizArgs, IfVizOptions} from '../types/process-args';
+
+const {ARGS, HELP} = CONFIG;
+const {MANIFEST_NOT_FOUND, INVALID_PORT_NUMBER} = STRINGS;
+
+/**
+ * Validates `if-viz` process arguments.
+ */
+const validateAndParseProcessArgs = (): IfVizArgs => {
+  try {
+    return parse<IfVizArgs>(ARGS, HELP);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log(error.message);
+      console.log('Here are the supported flags for the `if-viz` command:');
+      parse<IfVizArgs>(ARGS, {...HELP, argv: ['--help'], processExitCode: 1});
+    }
+    throw error;
+  }
+};
+
+/**
+ * Parse and validate command line arguments for `if-viz`.
+ */
+export const parseIfVizArgs = async (): Promise<IfVizOptions> => {
+  const options = validateAndParseProcessArgs();
+
+  const port = parseInt(options.port, 10);
+  if (Number.isNaN(port) || port < 0 || port > 65535) {
+    throw new Error(INVALID_PORT_NUMBER(options.port));
+  }
+
+  const manifest = path.resolve(options.manifest);
+  const exists = await isFileExists(manifest);
+  if (!exists) {
+    throw new Error(MANIFEST_NOT_FOUND(manifest));
+  }
+
+  return {
+    manifest,
+    port,
+    noOpen: options['no-open'],
+  };
+};


### PR DESCRIPTION
- New `if-viz` command serves output manifests locally and opens the GSF visualiser
- Starts an Express static server with CORS headers on the manifest's directory
- Opens the user's default browser via the `open` package (cross-platform)
- Supports --port and --no-open flags
- Add CLAUDE.md for Claude Code context
- Add .scratch/ to .gitignore for local working files

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- 
- 


<!-- Make sure tests and lint pass on CI. -->

