### PR TITLE
time-sync: add min/max/median aggregation methods ; treat as constants during normalization (Fixes #918)

### DIFF
--- a/manifests/outputs/features/regroup/success.yaml
+++ b/manifests/outputs/features/regroup/success.yaml
@@ -14,7 +14,7 @@ execution:
     node-version: 18.19.1
     date-time: 2025-06-03T00:12:17.558Z (UTC)
     dependencies:
-      - '@grnsft/if-core@0.0.30'
+      - '@grnsft/if-core@0.0.31'
       - axios@1.8.3
       - csv-parse@5.5.6
       - csv-stringify@6.4.6

--- a/manifests/outputs/pipelines/pipeline-with-aggregate.yaml
+++ b/manifests/outputs/pipelines/pipeline-with-aggregate.yaml
@@ -214,7 +214,7 @@ execution:
     node-version: 18.19.1
     date-time: 2025-06-02T14:32:59.071Z (UTC)
     dependencies:
-      - '@grnsft/if-core@0.0.30'
+      - '@grnsft/if-core@0.0.31'
       - axios@1.8.3
       - csv-parse@5.5.6
       - csv-stringify@6.4.6

--- a/manifests/outputs/pipelines/scenario-3.yaml
+++ b/manifests/outputs/pipelines/scenario-3.yaml
@@ -22,7 +22,7 @@ execution:
     node-version: 18.19.1
     date-time: 2025-06-02T14:32:40.906Z (UTC)
     dependencies:
-      - '@grnsft/if-core@0.0.30'
+      - '@grnsft/if-core@0.0.31'
       - axios@1.8.3
       - csv-parse@5.5.6
       - csv-stringify@6.4.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@grnsft/if-core": "^0.0.30",
+        "@grnsft/if-core": "^0.0.31",
         "axios": "^1.7.2",
         "csv-parse": "^5.5.6",
         "csv-stringify": "^6.4.6",
@@ -44,6 +44,7 @@
         "@types/node": "^20.8.9",
         "axios-mock-adapter": "^1.22.0",
         "cross-env": "7.0.3",
+        "eslint": "^8.57.1",
         "fixpack": "^4.0.0",
         "gts": "^5.0.0",
         "husky": "^8.0.0",
@@ -1088,7 +1089,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.3",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1110,7 +1113,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.50.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1118,9 +1123,9 @@
       }
     },
     "node_modules/@grnsft/if-core": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@grnsft/if-core/-/if-core-0.0.30.tgz",
-      "integrity": "sha512-KBX/oYPJnXHSYIo8J27fzLOu0sCvHTbx09O1iHt6qZjrxirYOt9NnXgPlgOdxSg5ArRQNlmQs2G4loy90GeocA==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@grnsft/if-core/-/if-core-0.0.31.tgz",
+      "integrity": "sha512-6F4VhanSd0c5g/5txLk1g4jSzabS57jgkZGl0IqJ9+uf9DF3S4BNHYFuDB229CL6rkqQE0FJ+nalkwhQqRgkQg==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.8"
@@ -1131,12 +1136,15 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.13",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -1156,7 +1164,10 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.1",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2784,6 +2795,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2819,7 +2837,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2831,6 +2851,8 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2848,7 +2870,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4574,17 +4598,21 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.50.0",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -4814,6 +4842,8 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5665,7 +5695,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.23.0",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5748,6 +5780,150 @@
       },
       "peerDependencies": {
         "typescript": ">=3"
+      }
+    },
+    "node_modules/gts/node_modules/@eslint/js": {
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
+      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gts/node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/gts/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gts/node_modules/eslint": {
+      "version": "8.50.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
+      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "8.50.0",
+        "@humanwhocodes/config-array": "^0.11.11",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/gts/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gts/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gts/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gts/node_modules/rimraf": {
@@ -7405,6 +7581,8 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10883,6 +11061,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Green-Software-Foundation/if/issues/new?assignees=&labels=feedback&projects=&template=feedback.md&title=Feedback+-+"
   },
   "dependencies": {
-    "@grnsft/if-core": "^0.0.30",
+    "@grnsft/if-core": "^0.0.31",
     "axios": "^1.7.2",
     "csv-parse": "^5.5.6",
     "csv-stringify": "^6.4.6",
@@ -45,6 +45,7 @@
     "@types/node": "^20.8.9",
     "axios-mock-adapter": "^1.22.0",
     "cross-env": "7.0.3",
+    "eslint": "^8.57.1",
     "fixpack": "^4.0.0",
     "gts": "^5.0.0",
     "husky": "^8.0.0",

--- a/src/__tests__/if-run/lib/environment.test.ts
+++ b/src/__tests__/if-run/lib/environment.test.ts
@@ -47,7 +47,7 @@ describe('lib/environment: ', () => {
 
       expect.assertions(1);
       expect(response).toHaveProperty('execution');
-    }, 6000);
+    }, 5000);
 
     it('checks `execution` to have `command` and `environment` props.', async () => {
       // @ts-ignore

--- a/src/__tests__/if-run/util/aggregation-helper.test.ts
+++ b/src/__tests__/if-run/util/aggregation-helper.test.ts
@@ -171,5 +171,121 @@ describe('util/aggregation-helper: ', () => {
       const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
       expect(aggregated).toEqual(expectedValue);
     });
+    it('executes when aggregation properties are `min`.', () => {
+      storeAggregationMetrics({
+        carbon: {
+          time: 'min',
+          component: 'min',
+        },
+      });
+      const inputs: PluginParams[] = [
+        {timestamp: '', duration: 10, carbon: 10},
+        {timestamp: '', duration: 10, carbon: 20},
+      ];
+      const metrics: string[] = ['carbon'];
+      const isTemporal = true;
+
+      const expectedValue = {
+        timestamp: '',
+        duration: 10,
+        carbon: 10,
+      };
+      const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
+      expect(aggregated).toEqual(expectedValue);
+    });
+    it('executes when aggregation properties are `max`.', () => {
+      storeAggregationMetrics({
+        carbon: {
+          time: 'max',
+          component: 'max',
+        },
+      });
+      const inputs: PluginParams[] = [
+        {timestamp: '', duration: 10, carbon: 10},
+        {timestamp: '', duration: 10, carbon: 30},
+        {timestamp: '', duration: 10, carbon: 20},
+      ];
+      const metrics: string[] = ['carbon'];
+      const isTemporal = true;
+
+      const expectedValue = {
+        timestamp: '',
+        duration: 10,
+        carbon: 30,
+      };
+      const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
+      expect(aggregated).toEqual(expectedValue);
+    });
+    it('executes when aggregation properties are `median` for odd length.', () => {
+      storeAggregationMetrics({
+        carbon: {
+          time: 'median',
+          component: 'median',
+        },
+      });
+      const inputs: PluginParams[] = [
+        {timestamp: '', duration: 10, carbon: 1},
+        {timestamp: '', duration: 10, carbon: 9},
+        {timestamp: '', duration: 10, carbon: 5},
+      ];
+      const metrics: string[] = ['carbon'];
+      const isTemporal = true;
+
+      const expectedValue = {
+        timestamp: '',
+        duration: 10,
+        carbon: 5,
+      };
+      const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
+      expect(aggregated).toEqual(expectedValue);
+    });
+    it('executes when aggregation properties are `median` for even length.', () => {
+      storeAggregationMetrics({
+        carbon: {
+          time: 'median',
+          component: 'median',
+        },
+      });
+      const inputs: PluginParams[] = [
+        {timestamp: '', duration: 10, carbon: 1},
+        {timestamp: '', duration: 10, carbon: 100},
+        {timestamp: '', duration: 10, carbon: 9},
+        {timestamp: '', duration: 10, carbon: 4},
+      ];
+      const metrics: string[] = ['carbon'];
+      const isTemporal = true;
+
+      const expectedValue = {
+        timestamp: '',
+        duration: 10,
+        carbon: (4 + 9) / 2,
+      };
+      const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
+      expect(aggregated).toEqual(expectedValue);
+    });
+    it('coerces numeric strings and ignores non-finite values when reducing', () => {
+      storeAggregationMetrics({
+        carbon: {
+          time: 'min',
+          component: 'min',
+        },
+      });
+      const inputs: PluginParams[] = [
+        {timestamp: '', duration: 10, carbon: 10},
+        {timestamp: '', duration: 10, carbon: -2.5},
+        {timestamp: '', duration: 10, carbon: 'NaN'},
+        {timestamp: '', duration: 10, carbon: undefined},
+      ];
+      const metrics: string[] = ['carbon'];
+      const isTemporal = true;
+
+      const expectedValue = {
+        timestamp: '',
+        duration: 10,
+        carbon: -2.5,
+      };
+      const aggregated = aggregateOutputsIntoOne(inputs, metrics, isTemporal);
+      expect(aggregated).toEqual(expectedValue);
+    });
   });
 });

--- a/src/if-run/builtins/time-sync/README.md
+++ b/src/if-run/builtins/time-sync/README.md
@@ -92,6 +92,8 @@ Sometimes there might be discontinuities in the time series between one `observa
 
 To solve this problem, for all but the first `observation` in the `inputs` array, we grab the `timestamp` and `duration` from the previous `observation` and check that `timestamp[N] + duration[N] == timestamp[N+1]`. If this condition is not satisfied, we backfill the missing data with a "zero-observation" which is identical to the surrounding observations except any values whose `aggregation-method` is `sum` are set to zero. This is equivalent to assuming that when there is no data available, the app being monitored is switched off.
 
+For metrics whose `aggregation-method` is `min`, `max` or `median`, Time-Sync treats them as constant-like during normalization, so the gap is backfilled by copying the most recent available value rather than zeroing it. This preserves the semantic meaning of these statistics until they are properly reduced during the later aggregation stage.
+
 The end result of this gap-filling is that we have continuous 1 second resolution data that can be resampled to a new temporal resolution.
 
 ```ts
@@ -178,6 +180,7 @@ For example, for `interval = 10` and this time-series
 setting the `upsampling-resolution` to `10s` is preferable to the default behavior.  
 If the default behavior were used, the model would create `300` samples of `1s` each, which would be inefficient. By setting a custom `upsampling-resolution` of `10s`, the model only generates `30` samples, each representing `10s`.
 
+While for `sum`, the value is divided evenly across the slice so that the sum over the original duration is preserved, for `avg` or `copy` or `min` or `max` or `median`, it is treated like a per-second constant because using a base resolution can significantly reduce computation while still preserving the statistical meaning of these values during normalization.
 
 #### Assumptions and limitations
 

--- a/src/if-run/builtins/time-sync/index.ts
+++ b/src/if-run/builtins/time-sync/index.ts
@@ -140,6 +140,12 @@ export const TimeSync = PluginFactory<TimeNormalizerConfig>({
       throw new InvalidDateInInputError(INVALID_DATE_TYPE(date));
     };
 
+    const isConstantMethod = (method: string): boolean =>
+      method === 'copy' ||
+      method === 'min' ||
+      method === 'max' ||
+      method === 'median'; 
+
     /**
      * Calculates minimal factor.
      */
@@ -258,7 +264,7 @@ export const TimeSync = PluginFactory<TimeNormalizerConfig>({
           return acc;
         }
 
-        if (aggregationParams.time === 'copy') {
+        if (isConstantMethod(aggregationParams.time)) {
           acc[metric] = input[metric];
           return acc;
         }
@@ -336,7 +342,7 @@ export const TimeSync = PluginFactory<TimeNormalizerConfig>({
             return;
           }
 
-          if (aggregationParams.time === 'copy') {
+          if (isConstantMethod(aggregationParams.time)) {
             acc[metric] = input[metric];
 
             return;

--- a/src/if-run/util/aggregation-helper.ts
+++ b/src/if-run/util/aggregation-helper.ts
@@ -22,7 +22,10 @@ export const aggregateOutputsIntoOne = (
 ) => {
   const metricsWithTime = metrics.concat(AGGREGATION_TIME_METRICS);
 
-  return outputs.reduce((acc, output, index) => {
+  type MedianBuckets = Record<string, number[]>;
+  const medianBuckets: MedianBuckets = {};
+
+  const result = outputs.reduce((acc, output, index) => {
     for (const metric of metricsWithTime) {
       if (!(metric in output)) {
         throw new MissingAggregationParamError(METRIC_MISSING(metric, index));
@@ -38,6 +41,15 @@ export const aggregateOutputsIntoOne = (
         /** Checks either its a temporal aggregation (vertical), then chooses `component`, otherwise `time`.  */
         const aggregationType = isTemporal ? 'component' : 'time';
 
+        const method = aggregationParams[aggregationType] as
+          | 'none'
+          | 'copy'
+          | 'sum'
+          | 'avg'
+          | 'min'
+          | 'max'
+          | 'median';
+
         if (aggregationParams[aggregationType] === 'none') {
           continue;
         }
@@ -47,18 +59,68 @@ export const aggregateOutputsIntoOne = (
           continue;
         }
 
-        acc[metric] = acc[metric] ?? 0;
-        acc[metric] += parseFloat(output[metric]);
+        const n = Number(output[metric]);
+        const value = Number.isFinite(n) ? n : 0;
+
+        switch (method) {
+          case 'median': {
+            if (!medianBuckets[metric]) medianBuckets[metric] = [];
+            medianBuckets[metric]!.push(value);
+            break;
+          }
+          case 'min': {
+            const cur = (acc[metric] as number) ?? Number.POSITIVE_INFINITY;
+            acc[metric] = Math.min(cur, value);
+            break;
+          }
+          case 'max': {
+            const cur = (acc[metric] as number) ?? Number.NEGATIVE_INFINITY;
+            acc[metric] = Math.max(cur, value);
+            break;
+          }
+          case 'sum':
+          case 'avg': {
+            const cur = (acc[metric] as number) ?? 0;
+            acc[metric] = cur + value;
+            break;
+          }
+          default: {
+            throw new Error(
+              'Unsupported aggregation method: ${(String(method)} for ${metric}'
+            );
+            break;
+          }
+        }
 
         /** Checks for the last iteration. */
         if (index === outputs.length - 1) {
-          if (aggregationParams[aggregationType] === 'avg') {
+          switch (method) {
+            case 'avg': {
             acc[metric] /= outputs.length;
+            break;
           }
+          case 'median': {
+              const arr = medianBuckets[metric] ?? [];
+              if (arr.length === 0) {
+                acc[metric] = 0;
+              } else {
+                arr.sort((a, b) => a - b);
+                const mid = Math.floor(arr.length / 2);
+                acc[metric] =
+                  arr.length % 2 === 0
+                    ? (arr[mid - 1] + arr[mid]) / 2
+                    : arr[mid];
+              }
+              break;
+            }
+            default:
+              break;
         }
       }
     }
+  }
 
     return acc;
   }, {} as AggregationResult);
+  return result;
 };


### PR DESCRIPTION
## What
[x] Adds `min`, `max`, `median` to allowed aggregation methods.
[x] Handle these test cases in time-sync, treating them as `copy` equivalents
[x] Add unit tests
[x] Add documentation to time-sync README
## Why
To support edge cases where
## Context
Expands time sync and aggregation functionality
## SoW (scope of work)
[x] aggregation methods added
[x] time-sync updated to handle new methods
[x] documentation updated
[x] test cases added